### PR TITLE
Add a setting to retain projectile owner after hit when owner is disconnected

### DIFF
--- a/purpur-server/minecraft-patches/features/0021-Retain-owner-after-hit-when-owner-is-disconnected.patch
+++ b/purpur-server/minecraft-patches/features/0021-Retain-owner-after-hit-when-owner-is-disconnected.patch
@@ -1,0 +1,20 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Lemonzy <lemonzy.pro@gmail.com>
+Date: Wed, 28 May 2025 01:01:10 +0200
+Subject: [PATCH] Retain owner after hit when owner is disconnected
+
+Previously, due to a fix in Paper, projectiles would lose their owner when they hit an entity while the owner was disconnected from the server. This behavior caused issues with certain redstone contraptions relying on the projectile's owner.
+
+diff --git a/net/minecraft/world/entity/projectile/Projectile.java b/net/minecraft/world/entity/projectile/Projectile.java
+index 0a1cee73ee7d895dba55745647daa4870038515c..04e28b213561cdd3410329545d0152f0c36c4195 100644
+--- a/net/minecraft/world/entity/projectile/Projectile.java
++++ b/net/minecraft/world/entity/projectile/Projectile.java
+@@ -59,7 +59,7 @@ public abstract class Projectile extends Entity implements TraceableEntity {
+             this.cachedOwner = owner;
+         }
+         // Paper start - Refresh ProjectileSource for projectiles
+-        else {
++        else if (!this.level().purpurConfig.retainProjectileOwnerOnHitIfOwnerOffline) { // Purpur - Due to a fix in Paper, projectiles lose their owner when they hit an entity while the owner is disconnected from the server. This can render certain redstone contraptions unusable. This behavior can be adjusted via the 'retainProjectileOwnerOnHitIfOwnerOffline' configuration option.
+             this.ownerUUID = null;
+             this.cachedOwner = null;
+             this.projectileSource = null;

--- a/purpur-server/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
+++ b/purpur-server/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
@@ -3593,4 +3593,9 @@ public class PurpurWorldConfig {
         shearsCanDefuseTntChance = (float) getDouble("gameplay-mechanics.item.shears.defuse-tnt-chance", 0.00D);
         shearsCanDefuseTnt = shearsCanDefuseTntChance > 0.00F;
     }
+
+    public boolean retainProjectileOwnerOnHitIfOwnerOffline = false;
+    private void retainProjectileOwnerOnHitIfOwnerOffline() {
+        retainProjectileOwnerOnHitIfOwnerOffline = getBoolean("gameplay-mechanics.retain-projectile-owner-on-hit-if-owner-offline", true);
+    }
 }


### PR DESCRIPTION
After building a [wireless-activated teleporter](https://youtu.be/MxEMNUu06bk?si=tBaRy69Av7CZUxsX) on a Purpur server, my friends and I noticed that the teleporter stopped working after re-logging into the server. Interestingly, this mechanism functions correctly in Vanilla Minecraft.

Upon digging into the issue, I discovered that the `Owner` property of the arrow disappears when the owner logs out. This happens because the arrow continuously collides with an entity (specifically, a wind charge), and due to a fix implemented in Paper, the `Owner` is set to `null` when the owner is disconnected from the server.

I introduced a configuration option under `gameplay-mechanics.retain-projectile-owner-on-hit-if-owner-offline`. When enabled, this option prevents the projectile from losing its owner upon hitting an entity while the owner is offline, thereby restoring the expected behavior and ensuring compatibility with redstone contraptions that rely on projectile ownership.