### PR TITLE
Persist hidden items in permission-based ender chest rows

### DIFF
--- a/purpur-server/minecraft-patches/features/0003-Barrels-and-enderchests-6-rows.patch
+++ b/purpur-server/minecraft-patches/features/0003-Barrels-and-enderchests-6-rows.patch
@@ -84,7 +84,7 @@ index e77bfcd31cdcfd5836dc5db561e3fe2bc552a4b1..afa2ead0548766669201526d83f351c2
          return new ChestMenu(MenuType.GENERIC_9x6, containerId, inventory, container, 6);
      }
 diff --git a/net/minecraft/world/inventory/PlayerEnderChestContainer.java b/net/minecraft/world/inventory/PlayerEnderChestContainer.java
-index 4df3a32faf85595372f4b250482d852c985ea3ab..8347150af55119d772b797e79be412f7e17a0f1f 100644
+index 4df3a32faf85595372f4b250482d852c985ea3ab..b792b83a67293baaab02f5e46bad88afbfdfe0dc 100644
 --- a/net/minecraft/world/inventory/PlayerEnderChestContainer.java
 +++ b/net/minecraft/world/inventory/PlayerEnderChestContainer.java
 @@ -26,11 +26,18 @@ public class PlayerEnderChestContainer extends SimpleContainer {
@@ -112,7 +112,7 @@ index 4df3a32faf85595372f4b250482d852c985ea3ab..8347150af55119d772b797e79be412f7
  
      public void fromSlots(final ValueInput.TypedInputList<ItemStackWithSlot> list) {
 -        for (int i = 0; i < this.getContainerSize(); i++) {
-+        int storageSlotCount = org.purpurmc.purpur.PurpurConfig.enderChestPreserveHiddenItems ? super.getContainerSize() : this.getContainerSize(); // Purpur - preserve hidden ender chest rows
++        int storageSlotCount = org.purpurmc.purpur.PurpurConfig.enderChestSixRows && org.purpurmc.purpur.PurpurConfig.enderChestPreserveHiddenItems ? 54 : this.getContainerSize(); // Purpur - Barrels and enderchests 6 rows
 +        for (int i = 0; i < storageSlotCount; i++) {
              this.setItem(i, ItemStack.EMPTY);
          }
@@ -127,7 +127,7 @@ index 4df3a32faf85595372f4b250482d852c985ea3ab..8347150af55119d772b797e79be412f7
  
      public void storeAsSlots(final ValueOutput.TypedOutputList<ItemStackWithSlot> output) {
 -        for (int i = 0; i < this.getContainerSize(); i++) {
-+        int storageSlotCount = org.purpurmc.purpur.PurpurConfig.enderChestPreserveHiddenItems ? super.getContainerSize() : this.getContainerSize(); // Purpur - preserve hidden ender chest rows
++        int storageSlotCount = org.purpurmc.purpur.PurpurConfig.enderChestSixRows && org.purpurmc.purpur.PurpurConfig.enderChestPreserveHiddenItems ? 54 : this.getContainerSize(); // Purpur - Barrels and enderchests 6 rows
 +        for (int i = 0; i < storageSlotCount; i++) {
              ItemStack itemStack = this.getItem(i);
              if (!itemStack.isEmpty()) {

--- a/purpur-server/minecraft-patches/features/0003-Barrels-and-enderchests-6-rows.patch
+++ b/purpur-server/minecraft-patches/features/0003-Barrels-and-enderchests-6-rows.patch
@@ -84,7 +84,7 @@ index e77bfcd31cdcfd5836dc5db561e3fe2bc552a4b1..afa2ead0548766669201526d83f351c2
          return new ChestMenu(MenuType.GENERIC_9x6, containerId, inventory, container, 6);
      }
 diff --git a/net/minecraft/world/inventory/PlayerEnderChestContainer.java b/net/minecraft/world/inventory/PlayerEnderChestContainer.java
-index 4df3a32faf85595372f4b250482d852c985ea3ab..b792b83a67293baaab02f5e46bad88afbfdfe0dc 100644
+index 4df3a32faf85595372f4b250482d852c985ea3ab..e41cb93b2ebc51a03bec3df672a570d90050eca1 100644
 --- a/net/minecraft/world/inventory/PlayerEnderChestContainer.java
 +++ b/net/minecraft/world/inventory/PlayerEnderChestContainer.java
 @@ -26,11 +26,18 @@ public class PlayerEnderChestContainer extends SimpleContainer {
@@ -112,7 +112,7 @@ index 4df3a32faf85595372f4b250482d852c985ea3ab..b792b83a67293baaab02f5e46bad88af
  
      public void fromSlots(final ValueInput.TypedInputList<ItemStackWithSlot> list) {
 -        for (int i = 0; i < this.getContainerSize(); i++) {
-+        int storageSlotCount = org.purpurmc.purpur.PurpurConfig.enderChestSixRows && org.purpurmc.purpur.PurpurConfig.enderChestPreserveHiddenItems ? 54 : this.getContainerSize(); // Purpur - Barrels and enderchests 6 rows
++        int storageSlotCount = org.purpurmc.purpur.PurpurConfig.enderChestSixRows && org.purpurmc.purpur.PurpurConfig.enderChestPersistHiddenRows ? 54 : this.getContainerSize(); // Purpur - Barrels and enderchests 6 rows
 +        for (int i = 0; i < storageSlotCount; i++) {
              this.setItem(i, ItemStack.EMPTY);
          }
@@ -127,7 +127,7 @@ index 4df3a32faf85595372f4b250482d852c985ea3ab..b792b83a67293baaab02f5e46bad88af
  
      public void storeAsSlots(final ValueOutput.TypedOutputList<ItemStackWithSlot> output) {
 -        for (int i = 0; i < this.getContainerSize(); i++) {
-+        int storageSlotCount = org.purpurmc.purpur.PurpurConfig.enderChestSixRows && org.purpurmc.purpur.PurpurConfig.enderChestPreserveHiddenItems ? 54 : this.getContainerSize(); // Purpur - Barrels and enderchests 6 rows
++        int storageSlotCount = org.purpurmc.purpur.PurpurConfig.enderChestSixRows && org.purpurmc.purpur.PurpurConfig.enderChestPersistHiddenRows ? 54 : this.getContainerSize(); // Purpur - Barrels and enderchests 6 rows
 +        for (int i = 0; i < storageSlotCount; i++) {
              ItemStack itemStack = this.getItem(i);
              if (!itemStack.isEmpty()) {

--- a/purpur-server/minecraft-patches/features/0003-Barrels-and-enderchests-6-rows.patch
+++ b/purpur-server/minecraft-patches/features/0003-Barrels-and-enderchests-6-rows.patch
@@ -84,7 +84,7 @@ index e77bfcd31cdcfd5836dc5db561e3fe2bc552a4b1..afa2ead0548766669201526d83f351c2
          return new ChestMenu(MenuType.GENERIC_9x6, containerId, inventory, container, 6);
      }
 diff --git a/net/minecraft/world/inventory/PlayerEnderChestContainer.java b/net/minecraft/world/inventory/PlayerEnderChestContainer.java
-index 4df3a32faf85595372f4b250482d852c985ea3ab..e41cb93b2ebc51a03bec3df672a570d90050eca1 100644
+index 4df3a32faf85595372f4b250482d852c985ea3ab..33c4c2cc8b488df5276d21e0f4e29cc0072a7682 100644
 --- a/net/minecraft/world/inventory/PlayerEnderChestContainer.java
 +++ b/net/minecraft/world/inventory/PlayerEnderChestContainer.java
 @@ -26,11 +26,18 @@ public class PlayerEnderChestContainer extends SimpleContainer {
@@ -107,19 +107,21 @@ index 4df3a32faf85595372f4b250482d852c985ea3ab..e41cb93b2ebc51a03bec3df672a570d9
      public void setActiveChest(final EnderChestBlockEntity activeChest) {
          this.activeChest = activeChest;
      }
-@@ -40,19 +47,21 @@ public class PlayerEnderChestContainer extends SimpleContainer {
+@@ -40,19 +47,25 @@ public class PlayerEnderChestContainer extends SimpleContainer {
      }
  
      public void fromSlots(final ValueInput.TypedInputList<ItemStackWithSlot> list) {
 -        for (int i = 0; i < this.getContainerSize(); i++) {
-+        int storageSlotCount = org.purpurmc.purpur.PurpurConfig.enderChestSixRows && org.purpurmc.purpur.PurpurConfig.enderChestPersistHiddenRows ? 54 : this.getContainerSize(); // Purpur - Barrels and enderchests 6 rows
++        // Purpur start - Barrels and enderchests 6 rows
++        int storageSlotCount = org.purpurmc.purpur.PurpurConfig.enderChestSixRows && org.purpurmc.purpur.PurpurConfig.enderChestPersistHiddenRows ? 54 : this.getContainerSize();
 +        for (int i = 0; i < storageSlotCount; i++) {
++        // Purpur end - Barrels and enderchests 6 rows
              this.setItem(i, ItemStack.EMPTY);
          }
  
          for (ItemStackWithSlot item : list) {
 -            if (item.isValidInContainer(this.getContainerSize())) {
-+            if (item.isValidInContainer(storageSlotCount)) {
++            if (item.isValidInContainer(storageSlotCount)) { // Purpur - Barrels and enderchests 6 rows
                  this.setItem(item.slot(), item.stack());
              }
          }
@@ -127,8 +129,10 @@ index 4df3a32faf85595372f4b250482d852c985ea3ab..e41cb93b2ebc51a03bec3df672a570d9
  
      public void storeAsSlots(final ValueOutput.TypedOutputList<ItemStackWithSlot> output) {
 -        for (int i = 0; i < this.getContainerSize(); i++) {
++        // Purpur start - Barrels and enderchests 6 rows
 +        int storageSlotCount = org.purpurmc.purpur.PurpurConfig.enderChestSixRows && org.purpurmc.purpur.PurpurConfig.enderChestPersistHiddenRows ? 54 : this.getContainerSize(); // Purpur - Barrels and enderchests 6 rows
 +        for (int i = 0; i < storageSlotCount; i++) {
++        // Purpur end - Barrels and enderchests 6 rows
              ItemStack itemStack = this.getItem(i);
              if (!itemStack.isEmpty()) {
                  output.add(new ItemStackWithSlot(i, itemStack));

--- a/purpur-server/minecraft-patches/features/0003-Barrels-and-enderchests-6-rows.patch
+++ b/purpur-server/minecraft-patches/features/0003-Barrels-and-enderchests-6-rows.patch
@@ -107,6 +107,31 @@ index 4df3a32faf85595372f4b250482d852c985ea3ab..8347150af55119d772b797e79be412f7
      public void setActiveChest(final EnderChestBlockEntity activeChest) {
          this.activeChest = activeChest;
      }
+@@ -40,19 +47,21 @@ public class PlayerEnderChestContainer extends SimpleContainer {
+     }
+ 
+     public void fromSlots(final ValueInput.TypedInputList<ItemStackWithSlot> list) {
+-        for (int i = 0; i < this.getContainerSize(); i++) {
++        int storageSlotCount = super.getContainerSize(); // Purpur - preserve hidden ender chest rows
++        for (int i = 0; i < storageSlotCount; i++) {
+             this.setItem(i, ItemStack.EMPTY);
+         }
+ 
+         for (ItemStackWithSlot item : list) {
+-            if (item.isValidInContainer(this.getContainerSize())) {
++            if (item.isValidInContainer(storageSlotCount)) {
+                 this.setItem(item.slot(), item.stack());
+             }
+         }
+     }
+ 
+     public void storeAsSlots(final ValueOutput.TypedOutputList<ItemStackWithSlot> output) {
+-        for (int i = 0; i < this.getContainerSize(); i++) {
++        int storageSlotCount = super.getContainerSize(); // Purpur - preserve hidden ender chest rows
++        for (int i = 0; i < storageSlotCount; i++) {
+             ItemStack itemStack = this.getItem(i);
+             if (!itemStack.isEmpty()) {
+                 output.add(new ItemStackWithSlot(i, itemStack));
 diff --git a/net/minecraft/world/level/block/EnderChestBlock.java b/net/minecraft/world/level/block/EnderChestBlock.java
 index 24a2c411da0ebbb7f97d621bb76ff686621f9aae..7ba9e8f6414246b589ff423fac63f80505326505 100644
 --- a/net/minecraft/world/level/block/EnderChestBlock.java

--- a/purpur-server/minecraft-patches/features/0003-Barrels-and-enderchests-6-rows.patch
+++ b/purpur-server/minecraft-patches/features/0003-Barrels-and-enderchests-6-rows.patch
@@ -112,7 +112,7 @@ index 4df3a32faf85595372f4b250482d852c985ea3ab..8347150af55119d772b797e79be412f7
  
      public void fromSlots(final ValueInput.TypedInputList<ItemStackWithSlot> list) {
 -        for (int i = 0; i < this.getContainerSize(); i++) {
-+        int storageSlotCount = super.getContainerSize(); // Purpur - preserve hidden ender chest rows
++        int storageSlotCount = org.purpurmc.purpur.PurpurConfig.enderChestPreserveHiddenItems ? super.getContainerSize() : this.getContainerSize(); // Purpur - preserve hidden ender chest rows
 +        for (int i = 0; i < storageSlotCount; i++) {
              this.setItem(i, ItemStack.EMPTY);
          }
@@ -127,7 +127,7 @@ index 4df3a32faf85595372f4b250482d852c985ea3ab..8347150af55119d772b797e79be412f7
  
      public void storeAsSlots(final ValueOutput.TypedOutputList<ItemStackWithSlot> output) {
 -        for (int i = 0; i < this.getContainerSize(); i++) {
-+        int storageSlotCount = super.getContainerSize(); // Purpur - preserve hidden ender chest rows
++        int storageSlotCount = org.purpurmc.purpur.PurpurConfig.enderChestPreserveHiddenItems ? super.getContainerSize() : this.getContainerSize(); // Purpur - preserve hidden ender chest rows
 +        for (int i = 0; i < storageSlotCount; i++) {
              ItemStack itemStack = this.getItem(i);
              if (!itemStack.isEmpty()) {

--- a/purpur-server/src/main/java/org/purpurmc/purpur/PurpurConfig.java
+++ b/purpur-server/src/main/java/org/purpurmc/purpur/PurpurConfig.java
@@ -329,7 +329,7 @@ public class PurpurConfig {
     public static int barrelRows = 3;
     public static boolean enderChestSixRows = false;
     public static boolean enderChestPermissionRows = false;
-    public static boolean enderChestPreserveHiddenItems = true;
+    public static boolean enderChestPersistHiddenRows = true;
     public static boolean cryingObsidianValidForPortalFrame = false;
     public static int beeInsideBeeHive = 3;
     public static boolean anvilCumulativeCost = true;
@@ -374,7 +374,7 @@ public class PurpurConfig {
         enderChestSixRows = getBoolean("settings.blocks.ender_chest.six-rows", enderChestSixRows);
         org.bukkit.event.inventory.InventoryType.ENDER_CHEST.setDefaultSize(enderChestSixRows ? 54 : 27);
         enderChestPermissionRows = getBoolean("settings.blocks.ender_chest.use-permissions-for-rows", enderChestPermissionRows);
-        enderChestPreserveHiddenItems = getBoolean("settings.blocks.ender_chest.preserve-hidden-items", enderChestPreserveHiddenItems);
+        enderChestPersistHiddenRows = getBoolean("settings.blocks.ender_chest.persist-hidden-rows", enderChestPersistHiddenRows);
         cryingObsidianValidForPortalFrame = getBoolean("settings.blocks.crying_obsidian.valid-for-portal-frame", cryingObsidianValidForPortalFrame);
         beeInsideBeeHive = getInt("settings.blocks.beehive.max-bees-inside", beeInsideBeeHive);
         anvilCumulativeCost = getBoolean("settings.blocks.anvil.cumulative-cost", anvilCumulativeCost);

--- a/purpur-server/src/main/java/org/purpurmc/purpur/PurpurConfig.java
+++ b/purpur-server/src/main/java/org/purpurmc/purpur/PurpurConfig.java
@@ -329,6 +329,7 @@ public class PurpurConfig {
     public static int barrelRows = 3;
     public static boolean enderChestSixRows = false;
     public static boolean enderChestPermissionRows = false;
+    public static boolean enderChestPreserveHiddenItems = true;
     public static boolean cryingObsidianValidForPortalFrame = false;
     public static int beeInsideBeeHive = 3;
     public static boolean anvilCumulativeCost = true;
@@ -373,6 +374,7 @@ public class PurpurConfig {
         enderChestSixRows = getBoolean("settings.blocks.ender_chest.six-rows", enderChestSixRows);
         org.bukkit.event.inventory.InventoryType.ENDER_CHEST.setDefaultSize(enderChestSixRows ? 54 : 27);
         enderChestPermissionRows = getBoolean("settings.blocks.ender_chest.use-permissions-for-rows", enderChestPermissionRows);
+        enderChestPreserveHiddenItems = getBoolean("settings.blocks.ender_chest.preserve-hidden-items", enderChestPreserveHiddenItems);
         cryingObsidianValidForPortalFrame = getBoolean("settings.blocks.crying_obsidian.valid-for-portal-frame", cryingObsidianValidForPortalFrame);
         beeInsideBeeHive = getInt("settings.blocks.beehive.max-bees-inside", beeInsideBeeHive);
         anvilCumulativeCost = getBoolean("settings.blocks.anvil.cumulative-cost", anvilCumulativeCost);


### PR DESCRIPTION
~~This fixes item loss with permission-based ender chest rows.~~

~~Previously, `PlayerEnderChestContainer#getContainerSize()` returned the player’s currently permitted row count, and the ender chest load/save methods also used that value. If a player stored items in higher rows and later lost the corresponding permission, those hidden slots could be skipped during load/save and omitted from saved player data.~~

~~This changes ender chest persistence to use the full backing container size while keeping the permission-limited size for access/UI behavior. Hidden rows remain inaccessible without permission, but their contents stay saved and become available again if the player regains the required permission.~~

EDIT: This adds support for preserving ender chest contents in rows hidden by permission-based row limits.

Currently, when permission-based ender chest rows are enabled, reducing a player’s allowed row count also reduces the size used by ender chest load/save logic. As a result, slots outside the player’s current permission range are not retained. This change keeps the existing permission-based access behavior intact: players can only view and interact with rows they currently have permission for. The new behavior is that hidden rows remain part of the backing storage during persistence, so their contents can be retained and become available again if the player regains the required row permission.

- Closes https://github.com/PurpurMC/Purpur/issues/1773

@/BillyGalbreath says this is not a bug and is working as intended, asked if it instead it could be intended to work this way. Hence the strike-through and rename