### PR TITLE
Fix sneak-to-bulk-process

### DIFF
--- a/purpur-server/minecraft-patches/sources/net/minecraft/world/level/block/ComposterBlock.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/world/level/block/ComposterBlock.java.patch
@@ -20,7 +20,7 @@
 +            if (newState == null) {
 +                return InteractionResult.PASS;
 +            }
-+            if (level.purpurConfig.composterBulkProcess && player.isShiftKeyDown() && newState != state) {
++            if (level.purpurConfig.composterBulkProcess && player.isShiftKeyDown()) {
 +                BlockState oldState;
 +                int oldCount, newCount, oldLevel, newLevel;
 +                do {
@@ -33,7 +33,7 @@
 +                    }
 +                    newCount = itemStack.getCount();
 +                    newLevel = newState.getValue(ComposterBlock.LEVEL);
-+                } while (newCount > 0 && (newCount != oldCount || newLevel != oldLevel || newState != oldState));
++                } while (newCount > 0 && (newCount != oldCount || newLevel != oldLevel));
 +            }
 +            // Purpur end - Sneak to bulk process composter
  


### PR DESCRIPTION
Looking at the code, `addItem()` uses a `willRaiseLevel` boolean to determine whether the composter's level should increase.

When `willRaiseLevel` is false, `addItem()` returns the original `BlockState`. meaning, `newState == state`, causing the `if` condition to be `false`.

This means sneak bulk processing only starts when the first attempt successfully raises the composter level. If the first attempt fails its compost chance, only a single item is processed instead of continuing until the composter is full.

The fix is to remove the state check, I tested it and it works as intended.

Fixes #1778 