### PR TITLE
fix configurable daylight cycle not working

### DIFF
--- a/purpur-server/minecraft-patches/features/0001-Ridables.patch
+++ b/purpur-server/minecraft-patches/features/0001-Ridables.patch
@@ -18,7 +18,7 @@ index ec6dd9de7b82841b1403b1bb851392132be5275b..146c404ac0471ed7df6d3740859663aa
              public boolean isClientAuthoritative() {
                  return false;
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
-index 99f1c3d82e632e7328366dc8b02e8f26500f80ce..bc2be2db242d4cc5ad857ad97f32e42072f09f09 100644
+index 80e694615ff8f81c8cbda9684ef96cce65f5abd7..f9cf876c5031e20b209c5de991982dbe08c0a58f 100644
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
 @@ -1865,6 +1865,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -30,10 +30,10 @@ index 99f1c3d82e632e7328366dc8b02e8f26500f80ce..bc2be2db242d4cc5ad857ad97f32e420
              net.minecraft.world.level.block.entity.HopperBlockEntity.skipHopperEvents = level.paperConfig().hopper.disableMoveEvent || org.bukkit.event.inventory.InventoryMoveItemEvent.getHandlerList().getRegisteredListeners().length == 0; // Paper - Perf: Optimize Hoppers
              profiler.push(() -> level + " " + level.dimension().identifier());
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 72ce2b03561af86db2059dfa05f381278af56f64..ca39cddc5d7bccbea4ce8ed95354c7529dd93072 100644
+index 9a5be73c618c4c8572aad4ca2673def65658eeee..50a1fe6bd9f7e6cf79e48e1420fbe153c902bddb 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -239,6 +239,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -237,6 +237,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
      private static final org.bukkit.craftbukkit.persistence.CraftPersistentDataTypeRegistry DATA_TYPE_REGISTRY = new org.bukkit.craftbukkit.persistence.CraftPersistentDataTypeRegistry();
      public final org.bukkit.craftbukkit.persistence.CraftPersistentDataContainer persistentDataContainer = new org.bukkit.craftbukkit.persistence.CraftPersistentDataContainer(DATA_TYPE_REGISTRY);
      private final alternate.current.wire.WireHandler wireHandler = new alternate.current.wire.WireHandler(this); // Paper - optimize redstone (Alternate Current)
@@ -62,7 +62,7 @@ index 9529e56d83964589a1e55b64e666f66b4148c315..c7e81ed584a3da2521fad58049ee44c1
  
      private void updatePlayerAttributes() {
 diff --git a/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index c975f82d59c19d1bc8d1bce776af59ea5271e019..df58df768c938def010d2d215c61c906eda77429 100644
+index 4e92729e9afca5bcc1db04fd4eb252b02d6efd14..1840f3773c5aff928d440f6698efcce1b84d57e8 100644
 --- a/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -2983,6 +2983,8 @@ public class ServerGamePacketListenerImpl

--- a/purpur-server/minecraft-patches/sources/net/minecraft/server/level/ServerLevel.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/server/level/ServerLevel.java.patch
@@ -1,14 +1,5 @@
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -220,6 +_,8 @@
-     private final StructureManager structureManager;
-     private final StructureCheck structureCheck;
-     private final boolean tickTime;
-+    private double preciseTime; // Purpur - Configurable daylight cycle
-+    private boolean forceTime; // Purpur - Configurable daylight cycle
-     private final LevelDebugSynchronizers debugSynchronizers = new LevelDebugSynchronizers(this);
- 
-     // CraftBukkit start
 @@ -646,8 +_,25 @@
          // CraftBukkit end
          this.tickTime = tickTime;
@@ -36,14 +27,6 @@
          ChunkGenerator generator = levelStem.generator();
          // CraftBukkit start
          // Paper start - per-world time
-@@ -741,6 +_,7 @@
-         this.chunkDataController = new ca.spottedleaf.moonrise.patches.chunk_system.io.datacontroller.ChunkDataController((ServerLevel)(Object)this, this.chunkTaskScheduler);
-         // Paper end - rewrite chunk system
-         this.getCraftServer().addWorld(this.getWorld()); // CraftBukkit
-+        this.preciseTime = this.serverLevelData.getGameTime(); // Purpur - Configurable daylight cycle
-     }
- 
-     // Paper start
 @@ -809,7 +_,7 @@
          }
  

--- a/purpur-server/minecraft-patches/sources/net/minecraft/world/clock/ServerClockManager.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/world/clock/ServerClockManager.java.patch
@@ -1,17 +1,19 @@
 --- a/net/minecraft/world/clock/ServerClockManager.java
 +++ b/net/minecraft/world/clock/ServerClockManager.java
-@@ -149,12 +_,12 @@
- 
-     public ClientboundSetTimePacket createFullSyncPacket() {
-         // Paper start - per-player time
--        return this.createFullSyncPacket(null);
-+        return this.createFullSyncPacket(null); // Purpur - TODO: Configurable daylight cycle
-     }
- 
-     public ClientboundSetTimePacket createFullSyncPacket(final net.minecraft.server.level.ServerPlayer player) {
-         final Map<Holder<WorldClock>, ClockNetworkState> updates = new HashMap<>(this.clocks.size());
--        this.clocks.forEach((clock, instance) -> updates.put(clock, this.packNetworkState(clock, instance, player)));
-+        this.clocks.forEach((clock, instance) -> updates.put(clock, this.packNetworkState(clock, instance, player))); // Purpur - TODO: Configurable daylight cycle
-         return new ClientboundSetTimePacket(this.getGameTime(), updates);
-         // Paper end - per-player time
+@@ -70,7 +_,15 @@
+     public void tick() {
+         boolean advanceTime = this.advanceTime(); // Paper - per-world time
+         if (advanceTime) {
+-            this.clocks.values().forEach(ServerClockManager.ClockInstance::tick);
++            this.clocks.forEach(((worldClockHolder, clockInstance) -> { // Purpur start - Configurable daylight cycle
++                ServerLevel l = level != null ? level : server.overworld();
++                int incrementTicks = 12000 / (l.isBrightOutside() ? l.purpurConfig.daytimeTicks : l.purpurConfig.nighttimeTicks);
++                float rate = clockInstance.rate;
++                clockInstance.rate *= incrementTicks;
++                clockInstance.tick();
++                clockInstance.rate = rate;
++                this.broadcastUpdates(worldClockHolder, clockInstance);
++            })); // Purpur end - Configurable daylight cycle
+             this.setDirty();
+         }
      }


### PR DESCRIPTION
Add back the configurable daylight cycle feature by updating the clock instances on every tick.

`incrementTicks` is the config value that gets multiplied by the clock instance `rate` (So that our custom daylight cycle will also respect the rate if provided using `/time` etc). 

Clock instance's `rate` goes back to the original value so it won't overflow if it gets multiplied again and again.

Sync with the client's time using `broadcastUpdates()`

### Note: 
- This respects the Paper's config value `time.affects-all-worlds` meaning if this value is `true`, the daylight cycle will use the overworld ones (The cycle will be global than per-world, since this is easier to work with and maintain)

I tested various values, along with the time commands and rate, it works as intended.

Fixes #1776 