### PR TITLE
Fix creeper not having loot

### DIFF
--- a/purpur-server/minecraft-patches/features/0001-Ridables.patch
+++ b/purpur-server/minecraft-patches/features/0001-Ridables.patch
@@ -18,7 +18,7 @@ index ec6dd9de7b82841b1403b1bb851392132be5275b..146c404ac0471ed7df6d3740859663aa
              public boolean isClientAuthoritative() {
                  return false;
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
-index 99f1c3d82e632e7328366dc8b02e8f26500f80ce..bc2be2db242d4cc5ad857ad97f32e42072f09f09 100644
+index 80e694615ff8f81c8cbda9684ef96cce65f5abd7..f9cf876c5031e20b209c5de991982dbe08c0a58f 100644
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
 @@ -1865,6 +1865,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -62,7 +62,7 @@ index 9529e56d83964589a1e55b64e666f66b4148c315..c7e81ed584a3da2521fad58049ee44c1
  
      private void updatePlayerAttributes() {
 diff --git a/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index c975f82d59c19d1bc8d1bce776af59ea5271e019..df58df768c938def010d2d215c61c906eda77429 100644
+index 4e92729e9afca5bcc1db04fd4eb252b02d6efd14..1840f3773c5aff928d440f6698efcce1b84d57e8 100644
 --- a/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -2983,6 +2983,8 @@ public class ServerGamePacketListenerImpl
@@ -3174,7 +3174,7 @@ index d48e066e8c43494aa74158452da369e5617d6a7e..c1acc0a648493ec33ef4fc4a48b52fe0
          if (this.nextHeightOffsetChangeTick <= 0) {
              this.nextHeightOffsetChangeTick = 100;
 diff --git a/net/minecraft/world/entity/monster/Creeper.java b/net/minecraft/world/entity/monster/Creeper.java
-index 5b56fa1f7dadc63e7edbf54576327bbcb7f5f2a2..81031650d914c5d973d5bd89547ce58e92b1acc6 100644
+index 2bec5dac197403894e3833c98b0193df931740b7..c1ce9166cbe5c7b4e881141482052b4a537ceb7b 100644
 --- a/net/minecraft/world/entity/monster/Creeper.java
 +++ b/net/minecraft/world/entity/monster/Creeper.java
 @@ -57,21 +57,98 @@ public class Creeper extends Monster {
@@ -3276,7 +3276,7 @@ index 5b56fa1f7dadc63e7edbf54576327bbcb7f5f2a2..81031650d914c5d973d5bd89547ce58e
          this.targetSelector.addGoal(1, new NearestAttackableTargetGoal<>(this, Player.class, true));
          this.targetSelector.addGoal(2, new HurtByTargetGoal(this));
      }
-@@ -313,6 +390,7 @@ public class Creeper extends Monster {
+@@ -314,6 +391,7 @@ public class Creeper extends Monster {
              com.destroystokyo.paper.event.entity.CreeperIgniteEvent event = new com.destroystokyo.paper.event.entity.CreeperIgniteEvent((org.bukkit.entity.Creeper) getBukkitEntity(), ignited);
              if (event.callEvent()) {
                  this.entityData.set(DATA_IS_IGNITED, event.isIgnited());

--- a/purpur-server/minecraft-patches/features/0016-Toggle-for-water-sensitive-mob-damage.patch
+++ b/purpur-server/minecraft-patches/features/0016-Toggle-for-water-sensitive-mob-damage.patch
@@ -715,10 +715,10 @@ index b553c6dd60bd23fba7ee3df9886561fc7640f104..7f0e76437798f1bab7956722382e1517
  
      @Override
 diff --git a/net/minecraft/world/entity/monster/Creeper.java b/net/minecraft/world/entity/monster/Creeper.java
-index 893adb6acdb292c618753d12f6f891e0cce0f207..5b188b7121c62dc5c6ded6128e8f3b6a4d930fb0 100644
+index 911a438c6c9a727adf8efb1a860aec55c3290fa5..8893d902e60a43e9a6e1cec8dfb43b7aa72926e6 100644
 --- a/net/minecraft/world/entity/monster/Creeper.java
 +++ b/net/minecraft/world/entity/monster/Creeper.java
-@@ -265,6 +265,13 @@ public class Creeper extends Monster {
+@@ -266,6 +266,13 @@ public class Creeper extends Monster {
      }
      // Purpur end - Config to make Creepers explode on death
  

--- a/purpur-server/minecraft-patches/features/0019-Mobs-always-drop-experience.patch
+++ b/purpur-server/minecraft-patches/features/0019-Mobs-always-drop-experience.patch
@@ -725,10 +725,10 @@ index 7f0e76437798f1bab7956722382e1517f8f71121..257563b578762837cbea855fa42831f3
      protected void registerGoals() {
          this.goalSelector.addGoal(0, new org.purpurmc.purpur.entity.ai.HasRider(this)); // Purpur - Ridables
 diff --git a/net/minecraft/world/entity/monster/Creeper.java b/net/minecraft/world/entity/monster/Creeper.java
-index 5b188b7121c62dc5c6ded6128e8f3b6a4d930fb0..9d8b9e3e21ee721f5ea9339143839eeaebd341ae 100644
+index 8893d902e60a43e9a6e1cec8dfb43b7aa72926e6..4127adba5d5efe4c2a85055ea478c8c946d920f3 100644
 --- a/net/minecraft/world/entity/monster/Creeper.java
 +++ b/net/minecraft/world/entity/monster/Creeper.java
-@@ -272,6 +272,13 @@ public class Creeper extends Monster {
+@@ -273,6 +273,13 @@ public class Creeper extends Monster {
      }
      // Purpur end - Toggle for water sensitive mob damage
  

--- a/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/monster/Creeper.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/monster/Creeper.java.patch
@@ -8,7 +8,7 @@
  
      public Creeper(final EntityType<? extends Creeper> type, final Level level) {
          super(type, level);
-@@ -159,6 +_,26 @@
+@@ -159,6 +_,27 @@
          return false; // CraftBukkit
      }
  
@@ -29,6 +29,7 @@
 +        if (!this.exploding && this.level().purpurConfig.creeperExplodeWhenKilled && source.getEntity() instanceof net.minecraft.server.level.ServerPlayer) {
 +            this.explodeCreeper();
 +        }
++        super.dropAllDeathLoot(level, source);
 +    }
 +    // Purpur end - Config to make Creepers explode on death
 +


### PR DESCRIPTION
Add missing `super` method call, which now makes the creeper drop loot.

Fixes #1789 