### PR TITLE
Add missing mob settings

### DIFF
--- a/purpur-server/minecraft-patches/features/0001-Ridables.patch
+++ b/purpur-server/minecraft-patches/features/0001-Ridables.patch
@@ -18,7 +18,7 @@ index ec6dd9de7b82841b1403b1bb851392132be5275b..146c404ac0471ed7df6d3740859663aa
              public boolean isClientAuthoritative() {
                  return false;
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
-index 80e694615ff8f81c8cbda9684ef96cce65f5abd7..f9cf876c5031e20b209c5de991982dbe08c0a58f 100644
+index 03930510d489fe0af20750ba20b639df845266be..b2b69fbf79f67ea75bad54178f59dd5dfa9d61d5 100644
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
 @@ -1865,6 +1865,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -42,7 +42,7 @@ index 9a5be73c618c4c8572aad4ca2673def65658eeee..50a1fe6bd9f7e6cf79e48e1420fbe153
      @Override
      public @Nullable LevelChunk getChunkIfLoaded(int x, int z) {
 diff --git a/net/minecraft/server/level/ServerPlayer.java b/net/minecraft/server/level/ServerPlayer.java
-index 9529e56d83964589a1e55b64e666f66b4148c315..c7e81ed584a3da2521fad58049ee44c18947ca23 100644
+index 01438fdfcd047c4d0e9a9f0ebfd9e01434161dc5..3db9626ae55aae9c9fef22771f06ac37c8ad2890 100644
 --- a/net/minecraft/server/level/ServerPlayer.java
 +++ b/net/minecraft/server/level/ServerPlayer.java
 @@ -775,6 +775,15 @@ public class ServerPlayer extends Player implements ca.spottedleaf.moonrise.patc
@@ -808,6 +808,24 @@ index 57127335a3c68fbf9ac3d64a8504c6e271a5d532..8296a5a5935a77b01f4d11b102f3159d
      @Override
      protected void addAdditionalSaveData(final ValueOutput output) {
          super.addAdditionalSaveData(output);
+diff --git a/net/minecraft/world/entity/animal/camel/CamelHusk.java b/net/minecraft/world/entity/animal/camel/CamelHusk.java
+index 9708a22cf72eb2f8e69a23fc4849f788fedffd83..d634818efe3e661d2edc1fabbe25f4f5c34b41ae 100644
+--- a/net/minecraft/world/entity/animal/camel/CamelHusk.java
++++ b/net/minecraft/world/entity/animal/camel/CamelHusk.java
+@@ -26,6 +26,13 @@ public class CamelHusk extends Camel {
+         super(type, level);
+     }
+ 
++    // Purpur start - Ridables
++    @Override
++    public boolean dismountsUnderwater() {
++        return level().purpurConfig.useDismountsUnderwaterTag ? super.dismountsUnderwater() : !level().purpurConfig.camelHuskRidableInWater;
++    }
++    // Purpur end - Ridables
++
+     @Override
+     public boolean removeWhenFarAway(final double distSqr) {
+         return true;
 diff --git a/net/minecraft/world/entity/animal/chicken/Chicken.java b/net/minecraft/world/entity/animal/chicken/Chicken.java
 index c646ab45fbfb4a5fd29b8ad4914cf115d2f674b5..b0191f605e6f5e7be78a44868bef1805fc2d005c 100644
 --- a/net/minecraft/world/entity/animal/chicken/Chicken.java
@@ -4111,10 +4129,61 @@ index c9091f9aed31ce23371539cb44695732b2ae4e9b..41cd8cef18309f1dcfdb5c45f6733bad
          profiler.pop();
          this.updateActivity();
 diff --git a/net/minecraft/world/entity/monster/breeze/Breeze.java b/net/minecraft/world/entity/monster/breeze/Breeze.java
-index eaa7eb69bdc819228bbab05b053844f1578294ba..dd1a4c7ee396572269aa3dfec12f6b01018a66c3 100644
+index eaa7eb69bdc819228bbab05b053844f1578294ba..76222d49e4f321d2d8f763cfeae3815ad40123d5 100644
 --- a/net/minecraft/world/entity/monster/breeze/Breeze.java
 +++ b/net/minecraft/world/entity/monster/breeze/Breeze.java
-@@ -234,6 +234,7 @@ public class Breeze extends Monster {
+@@ -79,6 +79,50 @@ public class Breeze extends Monster {
+         this.xpReward = 10;
+     }
+ 
++    // Purpur start - Ridables
++    @Override
++    public boolean isRidable() {
++        return level().purpurConfig.breezeRidable;
++    }
++
++    @Override
++    public boolean dismountsUnderwater() {
++        return level().purpurConfig.useDismountsUnderwaterTag ? super.dismountsUnderwater() : !level().purpurConfig.breezeRidableInWater;
++    }
++
++    @Override
++    public boolean isControllable() {
++        return level().purpurConfig.breezeControllable;
++    }
++
++    @Override
++    public boolean onSpacebar() {
++        if (getRider() != null && getRider().getBukkitEntity().hasPermission("allow.special.breeze")) {
++            shoot();
++        }
++        return false;
++    }
++
++    public boolean shoot() {
++        if (!(level() instanceof ServerLevel serverLevel)) return false;
++
++        org.bukkit.Location loc = ((org.bukkit.entity.LivingEntity) getBukkitEntity()).getEyeLocation();
++        org.bukkit.util.Vector target = loc.getDirection().normalize().multiply(100).add(loc.toVector());
++
++        net.minecraft.world.entity.projectile.hurtingprojectile.windcharge.BreezeWindCharge windCharge = new net.minecraft.world.entity.projectile.hurtingprojectile.windcharge.BreezeWindCharge(this, serverLevel);
++        Projectile.spawnProjectileUsingShoot(windCharge, serverLevel, net.minecraft.world.item.ItemStack.EMPTY, target.getX() - getX(), target.getY() - getFiringYPosition(), target.getZ() - getZ(), 0.7F, 5 - serverLevel.getDifficulty().getId() * 4
++        );
++        this.playSound(SoundEvents.BREEZE_SHOOT, 1.5F, 1.0F);
++        return true;
++    }
++
++    @Override
++    protected void registerGoals() {
++        this.goalSelector.addGoal(0, new org.purpurmc.purpur.entity.ai.HasRider(this));
++        this.targetSelector.addGoal(0, new org.purpurmc.purpur.entity.ai.HasRider(this));
++    }
++    // Purpur end - Ridables
++
+     @Override
+     public Brain<Breeze> getBrain() {
+         return (Brain<Breeze>)super.getBrain();
+@@ -234,6 +278,7 @@ public class Breeze extends Monster {
      protected void customServerAiStep(final ServerLevel level) {
          ProfilerFiller profiler = Profiler.get();
          profiler.push("breezeBrain");
@@ -4704,6 +4773,34 @@ index faff25abf54e00f38b10bdb47e37ab2d100f32fb..6bb58edc4317e33da1d6053b1c66a9ac
      @Override
      protected void defineSynchedData(final SynchedEntityData.Builder entityData) {
          super.defineSynchedData(entityData);
+diff --git a/net/minecraft/world/entity/monster/skeleton/Parched.java b/net/minecraft/world/entity/monster/skeleton/Parched.java
+index 986caff5325830c6d3eb0f6927c3294ae8b9ebe0..87e281968803650755ed8987077d87f73eb048d4 100644
+--- a/net/minecraft/world/entity/monster/skeleton/Parched.java
++++ b/net/minecraft/world/entity/monster/skeleton/Parched.java
+@@ -19,6 +19,23 @@ public class Parched extends AbstractSkeleton {
+         super(type, level);
+     }
+ 
++    // Purpur start - Ridables
++    @Override
++    public boolean isRidable() {
++        return level().purpurConfig.parchedRidable;
++    }
++
++    @Override
++    public boolean dismountsUnderwater() {
++        return level().purpurConfig.useDismountsUnderwaterTag ? super.dismountsUnderwater() : !level().purpurConfig.parchedRidableInWater;
++    }
++
++    @Override
++    public boolean isControllable() {
++        return level().purpurConfig.parchedControllable;
++    }
++    // Purpur end - Ridables
++
+     @Override
+     protected AbstractArrow getArrow(final ItemStack projectile, final float power, final @Nullable ItemStack firingWeapon) {
+         AbstractArrow arrow = super.getArrow(projectile, power, firingWeapon);
 diff --git a/net/minecraft/world/entity/monster/skeleton/Skeleton.java b/net/minecraft/world/entity/monster/skeleton/Skeleton.java
 index d9cb4a5b989ce684bbaf4eee3f642d29d6bf9d45..d92db02786ce6989ca5d8a2d7647e4f60a66ce82 100644
 --- a/net/minecraft/world/entity/monster/skeleton/Skeleton.java

--- a/purpur-server/minecraft-patches/features/0002-Configurable-entity-base-attributes.patch
+++ b/purpur-server/minecraft-patches/features/0002-Configurable-entity-base-attributes.patch
@@ -155,6 +155,34 @@ index 8296a5a5935a77b01f4d11b102f3159d97fc8a30..431f296bf651942cd390b7f383295eae
      @Override
      public SoundEvent getAmbientSound() {
          return SoundEvents.CAMEL_AMBIENT;
+diff --git a/net/minecraft/world/entity/animal/camel/CamelHusk.java b/net/minecraft/world/entity/animal/camel/CamelHusk.java
+index d634818efe3e661d2edc1fabbe25f4f5c34b41ae..1aa414f7912352c2815cdffd633db14fc11fa591 100644
+--- a/net/minecraft/world/entity/animal/camel/CamelHusk.java
++++ b/net/minecraft/world/entity/animal/camel/CamelHusk.java
+@@ -33,6 +33,23 @@ public class CamelHusk extends Camel {
+     }
+     // Purpur end - Ridables
+ 
++    // Purpur start - Configurable entity base attributes
++    @Override
++    public float generateMaxHealth(net.minecraft.util.RandomSource random) {
++        return (float) generateMaxHealth(this.level().purpurConfig.camelHuskMaxHealthMin, this.level().purpurConfig.camelHuskMaxHealthMax);
++    }
++
++    @Override
++    public double generateJumpStrength(net.minecraft.util.RandomSource random) {
++        return generateJumpStrength(this.level().purpurConfig.camelHuskJumpStrengthMin, this.level().purpurConfig.camelHuskJumpStrengthMax);
++    }
++
++    @Override
++    public double generateSpeed(net.minecraft.util.RandomSource random) {
++        return generateSpeed(this.level().purpurConfig.camelHuskMovementSpeedMin, this.level().purpurConfig.camelHuskMovementSpeedMax);
++    }
++    // Purpur end - Configurable entity base attributes
++
+     @Override
+     public boolean removeWhenFarAway(final double distSqr) {
+         return true;
 diff --git a/net/minecraft/world/entity/animal/chicken/Chicken.java b/net/minecraft/world/entity/animal/chicken/Chicken.java
 index b0191f605e6f5e7be78a44868bef1805fc2d005c..2d9043763be094376f75b88758a2f487ec89d7c0 100644
 --- a/net/minecraft/world/entity/animal/chicken/Chicken.java
@@ -1048,7 +1076,7 @@ index c1acc0a648493ec33ef4fc4a48b52fe0b3dc04b2..b553c6dd60bd23fba7ee3df9886561fc
      protected void registerGoals() {
          this.goalSelector.addGoal(0, new org.purpurmc.purpur.entity.ai.HasRider(this)); // Purpur - Ridables
 diff --git a/net/minecraft/world/entity/monster/Creeper.java b/net/minecraft/world/entity/monster/Creeper.java
-index 81031650d914c5d973d5bd89547ce58e92b1acc6..893adb6acdb292c618753d12f6f891e0cce0f207 100644
+index c1ce9166cbe5c7b4e881141482052b4a537ceb7b..911a438c6c9a727adf8efb1a860aec55c3290fa5 100644
 --- a/net/minecraft/world/entity/monster/Creeper.java
 +++ b/net/minecraft/world/entity/monster/Creeper.java
 @@ -137,6 +137,14 @@ public class Creeper extends Monster {
@@ -1366,6 +1394,25 @@ index 41cd8cef18309f1dcfdb5c45f6733bad10587303..f449875ed2ada648aef7f0cfff52c08e
      @Override
      protected Brain<Zoglin> makeBrain(final Brain.Packed packedBrain) {
          return BRAIN_PROVIDER.makeBrain(this, packedBrain);
+diff --git a/net/minecraft/world/entity/monster/breeze/Breeze.java b/net/minecraft/world/entity/monster/breeze/Breeze.java
+index 76222d49e4f321d2d8f763cfeae3815ad40123d5..3b4f2d38b7a102ea77140c9838c09196e99bb892 100644
+--- a/net/minecraft/world/entity/monster/breeze/Breeze.java
++++ b/net/minecraft/world/entity/monster/breeze/Breeze.java
+@@ -123,6 +123,14 @@ public class Breeze extends Monster {
+     }
+     // Purpur end - Ridables
+ 
++    // Purpur start - Configurable entity base attributes
++    @Override
++    public void initAttributes() {
++        this.getAttribute(Attributes.MAX_HEALTH).setBaseValue(this.level().purpurConfig.breezeMaxHealth);
++        this.getAttribute(Attributes.SCALE).setBaseValue(this.level().purpurConfig.breezeScale);
++    }
++    // Purpur end - Configurable entity base attributes
++
+     @Override
+     public Brain<Breeze> getBrain() {
+         return (Brain<Breeze>)super.getBrain();
 diff --git a/net/minecraft/world/entity/monster/creaking/Creaking.java b/net/minecraft/world/entity/monster/creaking/Creaking.java
 index a63b919b08b2fba048a338fe24ae2a1b90c869bd..bb0508e1273ff0ab8db37868b78d16f0c15e854d 100644
 --- a/net/minecraft/world/entity/monster/creaking/Creaking.java
@@ -1679,6 +1726,25 @@ index 6bb58edc4317e33da1d6053b1c66a9ac10fb6ad9..dd55f35c828beb57ae1f995ecbbacb95
      @Override
      protected void defineSynchedData(final SynchedEntityData.Builder entityData) {
          super.defineSynchedData(entityData);
+diff --git a/net/minecraft/world/entity/monster/skeleton/Parched.java b/net/minecraft/world/entity/monster/skeleton/Parched.java
+index 87e281968803650755ed8987077d87f73eb048d4..bddfca55704b586d11b6cc5905c80303928c5d4b 100644
+--- a/net/minecraft/world/entity/monster/skeleton/Parched.java
++++ b/net/minecraft/world/entity/monster/skeleton/Parched.java
+@@ -36,6 +36,14 @@ public class Parched extends AbstractSkeleton {
+     }
+     // Purpur end - Ridables
+ 
++    // Purpur start - Configurable entity base attributes
++    @Override
++    public void initAttributes() {
++        this.getAttribute(Attributes.MAX_HEALTH).setBaseValue(this.level().purpurConfig.parchedMaxHealth);
++        this.getAttribute(Attributes.SCALE).setBaseValue(this.level().purpurConfig.parchedScale);
++    }
++    // Purpur end - Configurable entity base attributes
++
+     @Override
+     protected AbstractArrow getArrow(final ItemStack projectile, final float power, final @Nullable ItemStack firingWeapon) {
+         AbstractArrow arrow = super.getArrow(projectile, power, firingWeapon);
 diff --git a/net/minecraft/world/entity/monster/skeleton/Skeleton.java b/net/minecraft/world/entity/monster/skeleton/Skeleton.java
 index d92db02786ce6989ca5d8a2d7647e4f60a66ce82..c48e758fe08b753bbc5fd1e9fe2568a220f7368e 100644
 --- a/net/minecraft/world/entity/monster/skeleton/Skeleton.java
@@ -1698,10 +1764,10 @@ index d92db02786ce6989ca5d8a2d7647e4f60a66ce82..c48e758fe08b753bbc5fd1e9fe2568a2
      protected void defineSynchedData(final SynchedEntityData.Builder entityData) {
          super.defineSynchedData(entityData);
 diff --git a/net/minecraft/world/entity/monster/skeleton/Stray.java b/net/minecraft/world/entity/monster/skeleton/Stray.java
-index ce8d70886fd84f10400a1bfee857434fe5e4857b..f028e74e34b16cfa4b5c808a8896521d4709d03f 100644
+index ce8d70886fd84f10400a1bfee857434fe5e4857b..20df146fd89837f1d294da871d11823f2a3d2507 100644
 --- a/net/minecraft/world/entity/monster/skeleton/Stray.java
 +++ b/net/minecraft/world/entity/monster/skeleton/Stray.java
-@@ -40,6 +40,13 @@ public class Stray extends AbstractSkeleton {
+@@ -40,6 +40,14 @@ public class Stray extends AbstractSkeleton {
      }
      // Purpur end - Ridables
  
@@ -1709,6 +1775,7 @@ index ce8d70886fd84f10400a1bfee857434fe5e4857b..f028e74e34b16cfa4b5c808a8896521d
 +    @Override
 +    public void initAttributes() {
 +        this.getAttribute(net.minecraft.world.entity.ai.attributes.Attributes.MAX_HEALTH).setBaseValue(this.level().purpurConfig.strayMaxHealth);
++        this.getAttribute(net.minecraft.world.entity.ai.attributes.Attributes.SCALE).setBaseValue(this.level().purpurConfig.strayScale);
 +    }
 +    // Purpur end - Configurable entity base attributes
 +

--- a/purpur-server/minecraft-patches/features/0015-Add-mobGriefing-override-to-everything-affected.patch
+++ b/purpur-server/minecraft-patches/features/0015-Add-mobGriefing-override-to-everything-affected.patch
@@ -239,6 +239,24 @@ index 5f2e20367e932566a268765707d91d58be42b90f..919cdb5087d484642deb871f7536f9fc
      }
  
      protected boolean canReplaceCurrentItem(final ItemStack newItemStack) {
+diff --git a/net/minecraft/world/entity/monster/skeleton/Parched.java b/net/minecraft/world/entity/monster/skeleton/Parched.java
+index bddfca55704b586d11b6cc5905c80303928c5d4b..cbd1f2f54e139cbe00f39b0abec763428321958d 100644
+--- a/net/minecraft/world/entity/monster/skeleton/Parched.java
++++ b/net/minecraft/world/entity/monster/skeleton/Parched.java
+@@ -44,6 +44,13 @@ public class Parched extends AbstractSkeleton {
+     }
+     // Purpur end - Configurable entity base attributes
+ 
++    // Purpur start - Check mobGriefing Overrides
++    @Override
++    protected Boolean checkEntityPickUpLootOverride() {
++        return this.level().purpurConfig.parchedCanPickUpLoot;
++    }
++    // Purpur end - Check mobGriefing Overrides
++
+     @Override
+     protected AbstractArrow getArrow(final ItemStack projectile, final float power, final @Nullable ItemStack firingWeapon) {
+         AbstractArrow arrow = super.getArrow(projectile, power, firingWeapon);
 diff --git a/net/minecraft/world/entity/projectile/Projectile.java b/net/minecraft/world/entity/projectile/Projectile.java
 index 9af4bf76974f05d9f752bbd4e8037560ec481cdf..7f3673a44b0200d18dbf7f1fac8d377bfc994232 100644
 --- a/net/minecraft/world/entity/projectile/Projectile.java

--- a/purpur-server/minecraft-patches/features/0016-Toggle-for-water-sensitive-mob-damage.patch
+++ b/purpur-server/minecraft-patches/features/0016-Toggle-for-water-sensitive-mob-damage.patch
@@ -992,6 +992,24 @@ index f449875ed2ada648aef7f0cfff52c08e94516d73..dec8f0ab0fd8f33dbc4b18d38e43ff15
      @Override
      protected Brain<Zoglin> makeBrain(final Brain.Packed packedBrain) {
          return BRAIN_PROVIDER.makeBrain(this, packedBrain);
+diff --git a/net/minecraft/world/entity/monster/breeze/Breeze.java b/net/minecraft/world/entity/monster/breeze/Breeze.java
+index 3b4f2d38b7a102ea77140c9838c09196e99bb892..aed4eb158430b75a6bc8a76c92b20ec795615301 100644
+--- a/net/minecraft/world/entity/monster/breeze/Breeze.java
++++ b/net/minecraft/world/entity/monster/breeze/Breeze.java
+@@ -131,6 +131,13 @@ public class Breeze extends Monster {
+     }
+     // Purpur end - Configurable entity base attributes
+ 
++    // Purpur start - Toggle for water sensitive mob damage
++    @Override
++    public boolean isSensitiveToWater() {
++        return this.level().purpurConfig.breezeTakeDamageFromWater;
++    }
++    // Purpur end - Toggle for water sensitive mob damage
++
+     @Override
+     public Brain<Breeze> getBrain() {
+         return (Brain<Breeze>)super.getBrain();
 diff --git a/net/minecraft/world/entity/monster/cubemob/MagmaCube.java b/net/minecraft/world/entity/monster/cubemob/MagmaCube.java
 index 54cc2ab970ec854ca44476a5e58b53363c64d1e5..44e8dd9667663e971c65613baef25f4d7ddf4a79 100644
 --- a/net/minecraft/world/entity/monster/cubemob/MagmaCube.java
@@ -1172,6 +1190,24 @@ index 3cbb6f2ee343e6d3851e84e53cb1aafa55418b0f..5f25162930b7d18385d84715f4f72962
      public static AttributeSupplier.Builder createAttributes() {
          return Monster.createMonsterAttributes()
              .add(Attributes.MAX_HEALTH, 50.0)
+diff --git a/net/minecraft/world/entity/monster/skeleton/Parched.java b/net/minecraft/world/entity/monster/skeleton/Parched.java
+index cbd1f2f54e139cbe00f39b0abec763428321958d..089d94c8c9224d294664b439e8edc76de9705728 100644
+--- a/net/minecraft/world/entity/monster/skeleton/Parched.java
++++ b/net/minecraft/world/entity/monster/skeleton/Parched.java
+@@ -51,6 +51,13 @@ public class Parched extends AbstractSkeleton {
+     }
+     // Purpur end - Check mobGriefing Overrides
+ 
++    // Purpur start - Toggle for water sensitive mob damage
++    @Override
++    public boolean isSensitiveToWater() {
++        return this.level().purpurConfig.parchedTakeDamageFromWater;
++    }
++    // Purpur end - Toggle for water sensitive mob damage
++
+     @Override
+     protected AbstractArrow getArrow(final ItemStack projectile, final float power, final @Nullable ItemStack firingWeapon) {
+         AbstractArrow arrow = super.getArrow(projectile, power, firingWeapon);
 diff --git a/net/minecraft/world/entity/monster/skeleton/Skeleton.java b/net/minecraft/world/entity/monster/skeleton/Skeleton.java
 index c48e758fe08b753bbc5fd1e9fe2568a220f7368e..cd9bbc34fa32629065170154eee303a7db8e8ab8 100644
 --- a/net/minecraft/world/entity/monster/skeleton/Skeleton.java
@@ -1191,10 +1227,10 @@ index c48e758fe08b753bbc5fd1e9fe2568a220f7368e..cd9bbc34fa32629065170154eee303a7
      protected void defineSynchedData(final SynchedEntityData.Builder entityData) {
          super.defineSynchedData(entityData);
 diff --git a/net/minecraft/world/entity/monster/skeleton/Stray.java b/net/minecraft/world/entity/monster/skeleton/Stray.java
-index f028e74e34b16cfa4b5c808a8896521d4709d03f..60aae5ecbd5d1243c63b304a7ffbfd729ad093c0 100644
+index 20df146fd89837f1d294da871d11823f2a3d2507..5b825aaa8d466a8242b44566c2520af1d584eafb 100644
 --- a/net/minecraft/world/entity/monster/skeleton/Stray.java
 +++ b/net/minecraft/world/entity/monster/skeleton/Stray.java
-@@ -47,6 +47,13 @@ public class Stray extends AbstractSkeleton {
+@@ -48,6 +48,13 @@ public class Stray extends AbstractSkeleton {
      }
      // Purpur end - Configurable entity base attributes
  

--- a/purpur-server/minecraft-patches/features/0017-API-for-any-mob-to-burn-daylight.patch
+++ b/purpur-server/minecraft-patches/features/0017-API-for-any-mob-to-burn-daylight.patch
@@ -232,7 +232,7 @@ index 3294aca7cb32d5cf9bbc7c2c99a538eb00fc3dcc..8f30f9f0f12e5fd6ddcb1809195f0823
      // Paper end - shouldBurnInDay API
  }
 diff --git a/net/minecraft/world/entity/monster/skeleton/Parched.java b/net/minecraft/world/entity/monster/skeleton/Parched.java
-index 986caff5325830c6d3eb0f6927c3294ae8b9ebe0..ed121e0b32a791ade0126edc627a96f713bc30d4 100644
+index 089d94c8c9224d294664b439e8edc76de9705728..37abb27ea0feeee7066c2c3d26659b6398281c1a 100644
 --- a/net/minecraft/world/entity/monster/skeleton/Parched.java
 +++ b/net/minecraft/world/entity/monster/skeleton/Parched.java
 @@ -17,6 +17,7 @@ import org.jspecify.annotations.Nullable;
@@ -242,7 +242,7 @@ index 986caff5325830c6d3eb0f6927c3294ae8b9ebe0..ed121e0b32a791ade0126edc627a96f7
 +        this.setShouldBurnInDay(false); // Purpur - API for any mob to burn daylight
      }
  
-     @Override
+     // Purpur start - Ridables
 diff --git a/net/minecraft/world/entity/monster/zombie/Husk.java b/net/minecraft/world/entity/monster/zombie/Husk.java
 index 83c2d21587fc490eb7eb60c43a21da73f144140c..afca08cfa58a25a7fa257eebf66dd888ccc1c734 100644
 --- a/net/minecraft/world/entity/monster/zombie/Husk.java

--- a/purpur-server/minecraft-patches/features/0019-Mobs-always-drop-experience.patch
+++ b/purpur-server/minecraft-patches/features/0019-Mobs-always-drop-experience.patch
@@ -58,6 +58,24 @@ index b3a47763c4dcb84cd5fc1003268582184fd595c2..f4483f893c301e338595cc2e79e9fe99
      @Override
      public long getPersistentAngerEndTime() {
          return this.entityData.get(DATA_ANGER_END_TIME);
+diff --git a/net/minecraft/world/entity/animal/camel/CamelHusk.java b/net/minecraft/world/entity/animal/camel/CamelHusk.java
+index 1aa414f7912352c2815cdffd633db14fc11fa591..57fd26345d8f7986bce0c8205889d3e785fd7917 100644
+--- a/net/minecraft/world/entity/animal/camel/CamelHusk.java
++++ b/net/minecraft/world/entity/animal/camel/CamelHusk.java
+@@ -50,6 +50,13 @@ public class CamelHusk extends Camel {
+     }
+     // Purpur end - Configurable entity base attributes
+ 
++    // Purpur start - Mobs always drop experience
++    @Override
++    protected boolean isAlwaysExperienceDropper() {
++        return this.level().purpurConfig.camelHuskAlwaysDropExp;
++    }
++    // Purpur end - Mobs always drop experience
++
+     @Override
+     public boolean removeWhenFarAway(final double distSqr) {
+         return true;
 diff --git a/net/minecraft/world/entity/animal/chicken/Chicken.java b/net/minecraft/world/entity/animal/chicken/Chicken.java
 index 71db913c66ae1efa9d335d45ab70c63ddfae3a91..31dda8f31967e1e02c2a9e32cc0586afa9c416e1 100644
 --- a/net/minecraft/world/entity/animal/chicken/Chicken.java
@@ -994,6 +1012,24 @@ index dec8f0ab0fd8f33dbc4b18d38e43ff1531963b07..35da647c8dad5da274ab8de857636d28
      @Override
      protected Brain<Zoglin> makeBrain(final Brain.Packed packedBrain) {
          return BRAIN_PROVIDER.makeBrain(this, packedBrain);
+diff --git a/net/minecraft/world/entity/monster/breeze/Breeze.java b/net/minecraft/world/entity/monster/breeze/Breeze.java
+index aed4eb158430b75a6bc8a76c92b20ec795615301..c46e4460d7bf27ced40e027c2b029d99c8098e27 100644
+--- a/net/minecraft/world/entity/monster/breeze/Breeze.java
++++ b/net/minecraft/world/entity/monster/breeze/Breeze.java
+@@ -138,6 +138,13 @@ public class Breeze extends Monster {
+     }
+     // Purpur end - Toggle for water sensitive mob damage
+ 
++    // Purpur start - Mobs always drop experience
++    @Override
++    protected boolean isAlwaysExperienceDropper() {
++        return this.level().purpurConfig.breezeAlwaysDropExp;
++    }
++    // Purpur end - Mobs always drop experience
++
+     @Override
+     public Brain<Breeze> getBrain() {
+         return (Brain<Breeze>)super.getBrain();
 diff --git a/net/minecraft/world/entity/monster/cubemob/MagmaCube.java b/net/minecraft/world/entity/monster/cubemob/MagmaCube.java
 index 44e8dd9667663e971c65613baef25f4d7ddf4a79..fd48929cb583662a76912f450aa4bf74abb05541 100644
 --- a/net/minecraft/world/entity/monster/cubemob/MagmaCube.java
@@ -1174,6 +1210,24 @@ index 5f25162930b7d18385d84715f4f72962c1efa93d..ee1a87f7811d22b5b33b3ae6b22fc533
      public static AttributeSupplier.Builder createAttributes() {
          return Monster.createMonsterAttributes()
              .add(Attributes.MAX_HEALTH, 50.0)
+diff --git a/net/minecraft/world/entity/monster/skeleton/Parched.java b/net/minecraft/world/entity/monster/skeleton/Parched.java
+index 37abb27ea0feeee7066c2c3d26659b6398281c1a..12a84a2cfbc81ddf87f3d0ed575bbd4cbe749b54 100644
+--- a/net/minecraft/world/entity/monster/skeleton/Parched.java
++++ b/net/minecraft/world/entity/monster/skeleton/Parched.java
+@@ -59,6 +59,13 @@ public class Parched extends AbstractSkeleton {
+     }
+     // Purpur end - Toggle for water sensitive mob damage
+ 
++    // Purpur start - Mobs always drop experience
++    @Override
++    protected boolean isAlwaysExperienceDropper() {
++        return this.level().purpurConfig.parchedAlwaysDropExp;
++    }
++    // Purpur end - Mobs always drop experience
++
+     @Override
+     protected AbstractArrow getArrow(final ItemStack projectile, final float power, final @Nullable ItemStack firingWeapon) {
+         AbstractArrow arrow = super.getArrow(projectile, power, firingWeapon);
 diff --git a/net/minecraft/world/entity/monster/skeleton/Skeleton.java b/net/minecraft/world/entity/monster/skeleton/Skeleton.java
 index cd9bbc34fa32629065170154eee303a7db8e8ab8..f7fe246c39f8588037171f16b6cd80be87b21547 100644
 --- a/net/minecraft/world/entity/monster/skeleton/Skeleton.java
@@ -1193,10 +1247,10 @@ index cd9bbc34fa32629065170154eee303a7db8e8ab8..f7fe246c39f8588037171f16b6cd80be
      protected void defineSynchedData(final SynchedEntityData.Builder entityData) {
          super.defineSynchedData(entityData);
 diff --git a/net/minecraft/world/entity/monster/skeleton/Stray.java b/net/minecraft/world/entity/monster/skeleton/Stray.java
-index 60aae5ecbd5d1243c63b304a7ffbfd729ad093c0..19ed23a4fc07f3a47f64ceefe1081b3641dfdccb 100644
+index 5b825aaa8d466a8242b44566c2520af1d584eafb..6262140e9f06c870c91fa1e91367ec2abadd6f6d 100644
 --- a/net/minecraft/world/entity/monster/skeleton/Stray.java
 +++ b/net/minecraft/world/entity/monster/skeleton/Stray.java
-@@ -54,6 +54,13 @@ public class Stray extends AbstractSkeleton {
+@@ -55,6 +55,13 @@ public class Stray extends AbstractSkeleton {
      }
      // Purpur end - Toggle for water sensitive mob damage
  

--- a/purpur-server/minecraft-patches/features/0021-Per-mob-mob_griefing-loot-pickup-override.patch
+++ b/purpur-server/minecraft-patches/features/0021-Per-mob-mob_griefing-loot-pickup-override.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Per mob mob_griefing loot pickup override
 
 
 diff --git a/net/minecraft/world/entity/Mob.java b/net/minecraft/world/entity/Mob.java
-index 00353f1668e4fb3d97c57175a5f141d6a39d70f7..524e37ac277eee9430a86b3a2dd69066f0d1b74f 100644
+index 3402444417535121cc9da4924ef9c4dbfb134b0e..a0342618ab9ffc2ed95f69a80c8f627d4d593326 100644
 --- a/net/minecraft/world/entity/Mob.java
 +++ b/net/minecraft/world/entity/Mob.java
 @@ -571,7 +571,7 @@ public abstract class Mob extends LivingEntity implements Targeting, EquipmentUs
@@ -31,7 +31,7 @@ index 00353f1668e4fb3d97c57175a5f141d6a39d70f7..524e37ac277eee9430a86b3a2dd69066
          return EquipmentSlot.HEAD;
      }
 diff --git a/net/minecraft/world/entity/animal/allay/Allay.java b/net/minecraft/world/entity/animal/allay/Allay.java
-index 80c86131486c7392481def252fa74d18ce76beb0..fe909b5d6689e0978a9efaad330f28e121865fc6 100644
+index cdca0b9d8765b760b132d65f4141779fd0278324..489e09f26aa3595317e70a26e14ff3018636911e 100644
 --- a/net/minecraft/world/entity/animal/allay/Allay.java
 +++ b/net/minecraft/world/entity/animal/allay/Allay.java
 @@ -163,6 +163,13 @@ public class Allay extends PathfinderMob implements InventoryCarrier, VibrationS
@@ -67,7 +67,7 @@ index a5c8c4cd7fb80ee0fb87eba85b6a3095223b849c..db20e27227430809704b2d6148d0ffa1
      // Paper start - Fix MC-153010 (dropCustomDeathLoot is only called when shouldDropLoot = true)
      protected boolean guaranteedToDropUndamaged(final net.minecraft.world.entity.EquipmentSlot slot) {
 diff --git a/net/minecraft/world/entity/monster/illager/Pillager.java b/net/minecraft/world/entity/monster/illager/Pillager.java
-index 9d6629c29dc471ef1db672cce4260a983d452cbd..55b7fc1c375edaf8c86294884da55d5d97e09e93 100644
+index b0a79d1c96362e2a50d4b3215f7449a7a5fb6e04..ed9052bfa3b9c19ffcc54d74a7a24c36ba476812 100644
 --- a/net/minecraft/world/entity/monster/illager/Pillager.java
 +++ b/net/minecraft/world/entity/monster/illager/Pillager.java
 @@ -104,6 +104,13 @@ public class Pillager extends AbstractIllager implements CrossbowAttackMob, Inve
@@ -103,7 +103,7 @@ index d42afe275f7a917d5784da2838972dff73f1476a..68b252bfd6bacc3952ffc610032cd8a0
      protected void registerGoals() {
          super.registerGoals();
 diff --git a/net/minecraft/world/entity/monster/piglin/Piglin.java b/net/minecraft/world/entity/monster/piglin/Piglin.java
-index 8d952bf8a063f5f5ebb8054295c7ff12f03d1572..432f6edccbfeffdec2a4b468137c8e035be9f74a 100644
+index e3ceb6f928fa428f80c6b2680564c8124b8e888d..61a1c9ab2daf48722678633deec94dc702776b8d 100644
 --- a/net/minecraft/world/entity/monster/piglin/Piglin.java
 +++ b/net/minecraft/world/entity/monster/piglin/Piglin.java
 @@ -148,6 +148,13 @@ public class Piglin extends AbstractPiglin implements CrossbowAttackMob, Invento
@@ -166,7 +166,7 @@ index dd55f35c828beb57ae1f995ecbbacb95ef982603..cece76ba9a5c58cc811af1fec415f8e7
      protected void defineSynchedData(final SynchedEntityData.Builder entityData) {
          super.defineSynchedData(entityData);
 diff --git a/net/minecraft/world/entity/monster/skeleton/Skeleton.java b/net/minecraft/world/entity/monster/skeleton/Skeleton.java
-index 661ca577e899287c895d8d5b2c7919d7340af9e7..0d9a1bbe3255f94bf9ef35591a01b596c6fa6a52 100644
+index f7fe246c39f8588037171f16b6cd80be87b21547..5f78e335e92e11a6640becf1e5bde7803373199e 100644
 --- a/net/minecraft/world/entity/monster/skeleton/Skeleton.java
 +++ b/net/minecraft/world/entity/monster/skeleton/Skeleton.java
 @@ -65,6 +65,13 @@ public class Skeleton extends AbstractSkeleton {
@@ -184,10 +184,10 @@ index 661ca577e899287c895d8d5b2c7919d7340af9e7..0d9a1bbe3255f94bf9ef35591a01b596
      protected void defineSynchedData(final SynchedEntityData.Builder entityData) {
          super.defineSynchedData(entityData);
 diff --git a/net/minecraft/world/entity/monster/skeleton/Stray.java b/net/minecraft/world/entity/monster/skeleton/Stray.java
-index 19ed23a4fc07f3a47f64ceefe1081b3641dfdccb..8188c9e34e0df679e3799bd184790d57f38635be 100644
+index 6262140e9f06c870c91fa1e91367ec2abadd6f6d..0b2779ec2917f9221691bf1d2fa9ed0ffbede93f 100644
 --- a/net/minecraft/world/entity/monster/skeleton/Stray.java
 +++ b/net/minecraft/world/entity/monster/skeleton/Stray.java
-@@ -61,6 +61,13 @@ public class Stray extends AbstractSkeleton {
+@@ -62,6 +62,13 @@ public class Stray extends AbstractSkeleton {
      }
      // Purpur end - Mobs always drop experience
  
@@ -256,7 +256,7 @@ index 75b57de8caf55d795ce10e115d657998fb86b401..de736df453541a2c4a71de9776558157
      public boolean isSunSensitive() {
          return this.shouldBurnInDay; // Purpur - moved to LivingEntity; keep methods for ABI compatibility - API for any mob to burn daylight
 diff --git a/net/minecraft/world/entity/monster/zombie/Zombie.java b/net/minecraft/world/entity/monster/zombie/Zombie.java
-index 0671b7c2a77d1173d58812abcfcad2461a42d240..7ec2345a45dc62cab2fa363ed24bae4bca02db72 100644
+index d4b92e44f9c211378f332398e2fc4233b55acf2d..6335b03c39452c2e8e46084e61cefcf8185d2580 100644
 --- a/net/minecraft/world/entity/monster/zombie/Zombie.java
 +++ b/net/minecraft/world/entity/monster/zombie/Zombie.java
 @@ -167,6 +167,13 @@ public class Zombie extends Monster {
@@ -274,7 +274,7 @@ index 0671b7c2a77d1173d58812abcfcad2461a42d240..7ec2345a45dc62cab2fa363ed24bae4b
      protected void registerGoals() {
          this.goalSelector.addGoal(0, new org.purpurmc.purpur.entity.ai.HasRider(this)); // Purpur - Ridables
 diff --git a/net/minecraft/world/entity/monster/zombie/ZombieVillager.java b/net/minecraft/world/entity/monster/zombie/ZombieVillager.java
-index e4be264d71c7980047194a86c5681020e822a67a..23a5cee36253c222d383cc8e9d5e492231da131e 100644
+index e797ac2444e7ec5c880db0a747ad301be5d3a94e..890f1d5e48daa41e050cfc3cec8391ed95545311 100644
 --- a/net/minecraft/world/entity/monster/zombie/ZombieVillager.java
 +++ b/net/minecraft/world/entity/monster/zombie/ZombieVillager.java
 @@ -147,6 +147,13 @@ public class ZombieVillager extends Zombie implements VillagerDataHolder {
@@ -328,7 +328,7 @@ index 64a6f4517f581f64a71382bdb302b71c68dc5396..a1ff5e589516bb46236ef1408f0f4f2f
      public Brain<Villager> getBrain() {
          return (Brain<Villager>)super.getBrain();
 diff --git a/net/minecraft/world/entity/raid/Raider.java b/net/minecraft/world/entity/raid/Raider.java
-index 457acdb4f5893303a4eea3d5e97404f1dcec8195..d4f15192c8fb7cc66c9e15ace3b72d7fc4ea575d 100644
+index fb25bceaf1535a1a07eef6188b4c3656512415bb..3c68ca6a9f2ccb8eb67f1dbb009222324dff7c8d 100644
 --- a/net/minecraft/world/entity/raid/Raider.java
 +++ b/net/minecraft/world/entity/raid/Raider.java
 @@ -396,7 +396,7 @@ public abstract class Raider extends PatrollingMonster {

--- a/purpur-server/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
+++ b/purpur-server/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
@@ -1457,6 +1457,23 @@ public class PurpurWorldConfig {
         boggedCanPickUpLoot = getBooleanOrDefault("mobs.bogged.can-pick-up-loot", boggedCanPickUpLoot);
     }
 
+    public boolean breezeRidable = false;
+    public boolean breezeRidableInWater = true;
+    public boolean breezeControllable = true;
+    public double breezeMaxHealth = 30.0D;
+    public double breezeScale = 1.0D;
+    public boolean breezeTakeDamageFromWater = false;
+    public boolean breezeAlwaysDropExp = false;
+    private void breezeSettings() {
+        breezeRidable = getBoolean("mobs.breeze.ridable", breezeRidable);
+        breezeRidableInWater = getBoolean("mobs.breeze.ridable-in-water", breezeRidableInWater);
+        breezeControllable = getBoolean("mobs.breeze.controllable", breezeControllable);
+        breezeMaxHealth = getDouble("mobs.breeze.attributes.max_health", breezeMaxHealth);
+        breezeScale = Mth.clamp(getDouble("mobs.breeze.attributes.scale", breezeScale), 0.0625D, 16.0D);
+        breezeTakeDamageFromWater = getBoolean("mobs.breeze.takes-damage-from-water", breezeTakeDamageFromWater);
+        breezeAlwaysDropExp = getBoolean("mobs.breeze.always-drop-exp", breezeAlwaysDropExp);
+    }
+
     public boolean camelRidableInWater = false;
     public double camelMaxHealthMin = 32.0D;
     public double camelMaxHealthMax = 32.0D;
@@ -1474,6 +1491,25 @@ public class PurpurWorldConfig {
         camelMovementSpeedMin = getDouble("mobs.camel.attributes.movement_speed.min", camelMovementSpeedMin);
         camelMovementSpeedMax = getDouble("mobs.camel.attributes.movement_speed.max", camelMovementSpeedMax);
         camelBreedingTicks = getInt("mobs.camel.breeding-delay-ticks", camelBreedingTicks);
+    }
+
+    public boolean camelHuskRidableInWater = false;
+    public double camelHuskMaxHealthMin = 32.0D;
+    public double camelHuskMaxHealthMax = 32.0D;
+    public double camelHuskJumpStrengthMin = 0.42D;
+    public double camelHuskJumpStrengthMax = 0.42D;
+    public double camelHuskMovementSpeedMin = 0.09D;
+    public double camelHuskMovementSpeedMax = 0.09D;
+    public boolean camelHuskAlwaysDropExp = false;
+    private void camelHuskSettings() {
+        camelHuskRidableInWater = getBoolean("mobs.camel_husk.ridable-in-water", camelHuskRidableInWater);
+        camelHuskMaxHealthMin = getDouble("mobs.camel_husk.attributes.max_health.min", camelHuskMaxHealthMin);
+        camelHuskMaxHealthMax = getDouble("mobs.camel_husk.attributes.max_health.max", camelHuskMaxHealthMax);
+        camelHuskJumpStrengthMin = getDouble("mobs.camel_husk.attributes.jump_strength.min", camelHuskJumpStrengthMin);
+        camelHuskJumpStrengthMax = getDouble("mobs.camel_husk.attributes.jump_strength.max", camelHuskJumpStrengthMax);
+        camelHuskMovementSpeedMin = getDouble("mobs.camel_husk.attributes.movement_speed.min", camelHuskMovementSpeedMin);
+        camelHuskMovementSpeedMax = getDouble("mobs.camel_husk.attributes.movement_speed.max", camelHuskMovementSpeedMax);
+        camelHuskAlwaysDropExp = getBoolean("mobs.camel_husk.always-drop-exp", camelHuskAlwaysDropExp);
     }
 
     public boolean catRidable = false;
@@ -2467,6 +2503,25 @@ public class PurpurWorldConfig {
         pandaBreedingTicks = getInt("mobs.panda.breeding-delay-ticks", pandaBreedingTicks);
         pandaTakeDamageFromWater = getBoolean("mobs.panda.takes-damage-from-water", pandaTakeDamageFromWater);
         pandaAlwaysDropExp = getBoolean("mobs.panda.always-drop-exp", pandaAlwaysDropExp);
+    }
+
+    public boolean parchedRidable = false;
+    public boolean parchedRidableInWater = true;
+    public boolean parchedControllable = true;
+    public double parchedMaxHealth = 16.0D;
+    public double parchedScale = 1.0D;
+    public boolean parchedTakeDamageFromWater = false;
+    public boolean parchedAlwaysDropExp = false;
+    public Boolean parchedCanPickUpLoot = null;
+    private void parchedSettings() {
+        parchedRidable = getBoolean("mobs.parched.ridable", parchedRidable);
+        parchedRidableInWater = getBoolean("mobs.parched.ridable-in-water", parchedRidableInWater);
+        parchedControllable = getBoolean("mobs.parched.controllable", parchedControllable);
+        parchedMaxHealth = getDouble("mobs.parched.attributes.max_health", parchedMaxHealth);
+        parchedScale = Mth.clamp(getDouble("mobs.parched.attributes.scale", parchedScale), 0.0625D, 16.0D);
+        parchedTakeDamageFromWater = getBoolean("mobs.parched.takes-damage-from-water", parchedTakeDamageFromWater);
+        parchedAlwaysDropExp = getBoolean("mobs.parched.always-drop-exp", parchedAlwaysDropExp);
+        parchedCanPickUpLoot = getBooleanOrDefault("mobs.parched.can-pick-up-loot", parchedCanPickUpLoot);
     }
 
     public boolean parrotRidable = false;


### PR DESCRIPTION
Add missing mob settings `parched`, `camel husk` and `breeze` settings.

Also, add a special to the breeze to be able to shoot wind charges using spacebar (The code for the shoot is taken from the `Shoot#tick` of the breeze.

I tested the values as usual and they work great.  

Docs https://github.com/PurpurMC/PurpurDocs/pull/124