### PR TITLE
Use stable bossbar IDs for Purpur TPS/RAM bars

### DIFF
--- a/purpur-server/src/main/java/org/purpurmc/purpur/task/BossBarTask.java
+++ b/purpur-server/src/main/java/org/purpurmc/purpur/task/BossBarTask.java
@@ -1,11 +1,15 @@
 package org.purpurmc.purpur.task;
 
 import net.kyori.adventure.bossbar.BossBar;
+import net.minecraft.server.level.ServerBossEvent;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.BossEvent;
 import org.bukkit.Bukkit;
+import org.bukkit.craftbukkit.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
 
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -14,18 +18,18 @@ import java.util.UUID;
 import org.purpurmc.purpur.util.MinecraftInternalPlugin;
 
 public abstract class BossBarTask extends BukkitRunnable {
-    private final Map<UUID, BossBar> bossbars = new HashMap<>();
+    private final Map<UUID, ServerBossEvent> bossbars = new HashMap<>();
     private boolean started;
 
-    abstract BossBar createBossBar();
+    abstract ServerBossEvent createBossBar(UUID id);
 
-    abstract void updateBossBar(BossBar bossbar, Player player);
+    abstract void updateBossBar(ServerBossEvent bossbar, Player player);
 
     @Override
     public void run() {
-        Iterator<Map.Entry<UUID, BossBar>> iter = bossbars.entrySet().iterator();
+        Iterator<Map.Entry<UUID, ServerBossEvent>> iter = bossbars.entrySet().iterator();
         while (iter.hasNext()) {
-            Map.Entry<UUID, BossBar> entry = iter.next();
+            Map.Entry<UUID, ServerBossEvent> entry = iter.next();
             Player player = Bukkit.getPlayer(entry.getKey());
             if (player == null) {
                 iter.remove();
@@ -48,9 +52,9 @@ public abstract class BossBarTask extends BukkitRunnable {
     }
 
     public boolean removePlayer(Player player) {
-        BossBar bossbar = this.bossbars.remove(player.getUniqueId());
+        ServerBossEvent bossbar = this.bossbars.remove(player.getUniqueId());
         if (bossbar != null) {
-            player.hideBossBar(bossbar);
+            bossbar.removePlayer(((CraftPlayer) player).getHandle());
             return true;
         }
         return false;
@@ -58,10 +62,10 @@ public abstract class BossBarTask extends BukkitRunnable {
 
     public void addPlayer(Player player) {
         removePlayer(player);
-        BossBar bossbar = createBossBar();
+        ServerBossEvent bossbar = createBossBar(createId(player));
         this.bossbars.put(player.getUniqueId(), bossbar);
         this.updateBossBar(bossbar, player);
-        player.showBossBar(bossbar);
+        bossbar.addPlayer(((CraftPlayer) player).getHandle());
     }
 
     public boolean hasPlayer(UUID uuid) {
@@ -117,5 +121,31 @@ public abstract class BossBarTask extends BukkitRunnable {
         RamBarTask.instance().removePlayer(player);
         TPSBarTask.instance().removePlayer(player);
         CompassTask.instance().removePlayer(player);
+    }
+
+    protected static BossEvent.BossBarColor toVanillaColor(BossBar.Color color) {
+        return switch (color) {
+            case PINK -> BossEvent.BossBarColor.PINK;
+            case BLUE -> BossEvent.BossBarColor.BLUE;
+            case RED -> BossEvent.BossBarColor.RED;
+            case GREEN -> BossEvent.BossBarColor.GREEN;
+            case YELLOW -> BossEvent.BossBarColor.YELLOW;
+            case PURPLE -> BossEvent.BossBarColor.PURPLE;
+            case WHITE -> BossEvent.BossBarColor.WHITE;
+        };
+    }
+
+    protected static BossEvent.BossBarOverlay toVanillaOverlay(BossBar.Overlay overlay) {
+        return switch (overlay) {
+            case PROGRESS -> BossEvent.BossBarOverlay.PROGRESS;
+            case NOTCHED_6 -> BossEvent.BossBarOverlay.NOTCHED_6;
+            case NOTCHED_10 -> BossEvent.BossBarOverlay.NOTCHED_10;
+            case NOTCHED_12 -> BossEvent.BossBarOverlay.NOTCHED_12;
+            case NOTCHED_20 -> BossEvent.BossBarOverlay.NOTCHED_20;
+        };
+    }
+
+    private UUID createId(Player player) {
+        return UUID.nameUUIDFromBytes(("purpur:" + getClass().getSimpleName() + ":" + player.getUniqueId()).getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/purpur-server/src/main/java/org/purpurmc/purpur/task/CompassTask.java
+++ b/purpur-server/src/main/java/org/purpurmc/purpur/task/CompassTask.java
@@ -1,7 +1,10 @@
 package org.purpurmc.purpur.task;
 
 import net.kyori.adventure.bossbar.BossBar;
-import net.kyori.adventure.text.Component;
+import io.papermc.paper.adventure.PaperAdventure;
+import net.minecraft.server.level.ServerBossEvent;
+
+import java.util.UUID;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.world.item.Items;
 import org.bukkit.entity.Player;
@@ -44,16 +47,18 @@ public class CompassTask extends BossBarTask {
     }
 
     @Override
-    BossBar createBossBar() {
-        return BossBar.bossBar(Component.text(""), PurpurConfig.commandCompassBarProgressPercent, PurpurConfig.commandCompassBarProgressColor, PurpurConfig.commandCompassBarProgressOverlay);
+    ServerBossEvent createBossBar(UUID id) {
+        ServerBossEvent bossbar = new ServerBossEvent(id, net.minecraft.network.chat.Component.empty(), toVanillaColor(PurpurConfig.commandCompassBarProgressColor), toVanillaOverlay(PurpurConfig.commandCompassBarProgressOverlay));
+        bossbar.setProgress(PurpurConfig.commandCompassBarProgressPercent);
+        return bossbar;
     }
 
     @Override
-    void updateBossBar(BossBar bossbar, Player player) {
+    void updateBossBar(ServerBossEvent bossbar, Player player) {
         float yaw = player.getLocation().getYaw();
         int length = PurpurConfig.commandCompassBarTitle.length();
         int pos = (int) ((normalize(yaw) * (length / 720F)) + (length / 2F));
-        bossbar.name(Component.text(PurpurConfig.commandCompassBarTitle.substring(pos - 25, pos + 25)));
+        bossbar.setName(PaperAdventure.asVanilla(net.kyori.adventure.text.Component.text(PurpurConfig.commandCompassBarTitle.substring(pos - 25, pos + 25))));
     }
 
     private float normalize(float yaw) {

--- a/purpur-server/src/main/java/org/purpurmc/purpur/task/RamBarTask.java
+++ b/purpur-server/src/main/java/org/purpurmc/purpur/task/RamBarTask.java
@@ -1,8 +1,12 @@
 package org.purpurmc.purpur.task;
 
 import net.kyori.adventure.bossbar.BossBar;
+import io.papermc.paper.adventure.PaperAdventure;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.minecraft.server.level.ServerBossEvent;
+
+import java.util.UUID;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import org.bukkit.entity.Player;
 import org.purpurmc.purpur.PurpurConfig;
@@ -27,21 +31,21 @@ public class RamBarTask extends BossBarTask {
     }
 
     @Override
-    BossBar createBossBar() {
-        return BossBar.bossBar(Component.text(""), 0.0F, instance().getBossBarColor(), PurpurConfig.commandRamBarProgressOverlay);
+    ServerBossEvent createBossBar(UUID id) {
+        return new ServerBossEvent(id, net.minecraft.network.chat.Component.empty(), toVanillaColor(instance().getBossBarColor()), toVanillaOverlay(PurpurConfig.commandRamBarProgressOverlay));
     }
 
     @Override
-    void updateBossBar(BossBar bossbar, Player player) {
-        bossbar.progress(getBossBarProgress());
-        bossbar.color(getBossBarColor());
-        bossbar.name(MiniMessage.miniMessage().deserialize(PurpurConfig.commandRamBarTitle,
+    void updateBossBar(ServerBossEvent bossbar, Player player) {
+        bossbar.setProgress(getBossBarProgress());
+        bossbar.setColor(toVanillaColor(getBossBarColor()));
+        bossbar.setName(PaperAdventure.asVanilla(MiniMessage.miniMessage().deserialize(PurpurConfig.commandRamBarTitle,
                 Placeholder.component("allocated", format(this.allocated)),
                 Placeholder.component("used", format(this.used)),
                 Placeholder.component("xmx", format(this.xmx)),
                 Placeholder.component("xms", format(this.xms)),
                 Placeholder.unparsed("percent", ((int) (this.percent * 100)) + "%")
-        ));
+        )));
     }
 
     @Override

--- a/purpur-server/src/main/java/org/purpurmc/purpur/task/TPSBarTask.java
+++ b/purpur-server/src/main/java/org/purpurmc/purpur/task/TPSBarTask.java
@@ -1,8 +1,12 @@
 package org.purpurmc.purpur.task;
 
 import net.kyori.adventure.bossbar.BossBar;
+import io.papermc.paper.adventure.PaperAdventure;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.minecraft.server.level.ServerBossEvent;
+
+import java.util.UUID;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import org.purpurmc.purpur.PurpurConfig;
 import org.bukkit.Bukkit;
@@ -22,19 +26,19 @@ public class TPSBarTask extends BossBarTask {
     }
 
     @Override
-    BossBar createBossBar() {
-        return BossBar.bossBar(Component.text(""), 0.0F, instance().getBossBarColor(), PurpurConfig.commandTPSBarProgressOverlay);
+    ServerBossEvent createBossBar(UUID id) {
+        return new ServerBossEvent(id, net.minecraft.network.chat.Component.empty(), toVanillaColor(instance().getBossBarColor()), toVanillaOverlay(PurpurConfig.commandTPSBarProgressOverlay));
     }
 
     @Override
-    void updateBossBar(BossBar bossbar, Player player) {
-        bossbar.progress(getBossBarProgress());
-        bossbar.color(getBossBarColor());
-        bossbar.name(MiniMessage.miniMessage().deserialize(PurpurConfig.commandTPSBarTitle,
+    void updateBossBar(ServerBossEvent bossbar, Player player) {
+        bossbar.setProgress(getBossBarProgress());
+        bossbar.setColor(toVanillaColor(getBossBarColor()));
+        bossbar.setName(PaperAdventure.asVanilla(MiniMessage.miniMessage().deserialize(PurpurConfig.commandTPSBarTitle,
                 Placeholder.component("tps", getTPSColor()),
                 Placeholder.component("mspt", getMSPTColor()),
                 Placeholder.component("ping", getPingColor(player.getPing()))
-        ));
+        )));
     }
 
     @Override


### PR DESCRIPTION
This changes Purpur’s internal TPS, RAM, and compass bossbars to use vanilla ServerBossEvent instances with deterministic per-player IDs.

Previously, BossBarTask created a new Adventure BossBar each time a player joined a backend server. Behind proxies that skip the configuration phase, stale client-side bossbars may not be cleared during server transfer. Since each backend created a new bossbar ID, the client could stack multiple TPS/RAM bars.

Using stable IDs based on the player UUID and task type makes the bossbars idempotent across backend transfers, so the next backend updates the same client-side bossbar instead of adding another one.

P.S, Yes, I used AI. I am not a professional java developer. It was looked over by a friend of mine that knows and understands java.