### PR TITLE
Fix registerMinecraftDisabledCommands using wrong default value

### DIFF
--- a/purpur-server/src/main/java/org/purpurmc/purpur/PurpurConfig.java
+++ b/purpur-server/src/main/java/org/purpurmc/purpur/PurpurConfig.java
@@ -603,7 +603,7 @@ public class PurpurConfig {
 
     public static boolean registerMinecraftDisabledCommands = false;
     private static void registerMinecraftDisabledCommands() {
-        registerMinecraftDisabledCommands = getBoolean("settings.register-minecraft-disabled-commands", registerMinecraftDebugCommands);
+        registerMinecraftDisabledCommands = getBoolean("settings.register-minecraft-disabled-commands", registerMinecraftDisabledCommands);
     }
 
     public static List<String> startupCommands = new ArrayList<>();


### PR DESCRIPTION
Fixes a copy-paste bug where registerMinecraftDisabledCommands was reading its default value from registerMinecraftDebugCommands instead of its own field. This caused the two settings to interfere with each other when toggled.

registerMinecraftDebugCommands defaults to false, so setting registerMinecraftDisabledCommands to true would still show as false on a config reload since it was reading the wrong field.