### PR TITLE
Add config option to disable book editing

### DIFF
--- a/purpur-server/minecraft-patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -51,10 +51,16 @@
                  this.disconnect(Component.translatable("multiplayer.disconnect.invalid_player_movement"), org.bukkit.event.player.PlayerKickEvent.Cause.INVALID_PLAYER_MOVEMENT); // Paper - kick event cause
                  return;
              }
-@@ -1345,6 +_,10 @@
+@@ -1345,6 +_,16 @@
              final int maxBookPageSize = pageMax.intValue();
              final double multiplier = Math.clamp(io.papermc.paper.configuration.GlobalConfiguration.get().itemValidation.bookSize.totalMultiplier, 0.3D, 1D);
              long byteAllowed = maxBookPageSize;
++            // Purpur start - Option to disable book editing
++            if (!org.purpurmc.purpur.PurpurConfig.enableBooks) {
++                this.disconnectAsync(Component.literal("Book editing is disabled on this server"), org.bukkit.event.player.PlayerKickEvent.Cause.ILLEGAL_ACTION);
++                return;
++            }
++            // Purpur end - Option to disable book editing
 +            // Purpur start - PlayerBookTooLargeEvent
 +            int slot = packet.slot();
 +            ItemStack itemstack = Inventory.isHotbarSlot(slot) || slot == Inventory.SLOT_OFFHAND ? this.player.getInventory().getItem(slot) : ItemStack.EMPTY;

--- a/purpur-server/src/main/java/org/purpurmc/purpur/PurpurConfig.java
+++ b/purpur-server/src/main/java/org/purpurmc/purpur/PurpurConfig.java
@@ -520,6 +520,11 @@ public class PurpurConfig {
         fixProjectileLootingTransfer = getBoolean("settings.fix-projectile-looting-transfer", fixProjectileLootingTransfer);
     }
 
+    public static boolean enableBooks = true;
+    private static void enableBooks() {
+        enableBooks = getBoolean("settings.enable-books", enableBooks);
+    }
+
     public static boolean clampAttributes = true;
     private static void clampAttributes() {
         clampAttributes = getBoolean("settings.clamp-attributes", clampAttributes);


### PR DESCRIPTION
Adds a new setting `enable-books` (default: true) in purpur.yml that allows server admins to completely disable book editing and signing. When set to false, players trying to edit books are disconnected with a clear message.

This provides a defense against book-based duplication exploits that have been used on Minecraft servers.