### PR TITLE
Add support for bow/crossbow bundle contents component

### DIFF
--- a/purpur-server/minecraft-patches/features/0022-config-for-turning-bundles-into-functional-quivers.patch
+++ b/purpur-server/minecraft-patches/features/0022-config-for-turning-bundles-into-functional-quivers.patch
@@ -38,7 +38,7 @@ index 81f1d4faebc38aa07a2c76c2c163584c8e5b624c..9bc487ebec9660682592ec99cda190d0
              Predicate<ItemStack> supportedProjectiles = ((ProjectileWeaponItem)heldWeapon.getItem()).getSupportedHeldProjectiles();
              ItemStack heldProjectile = ProjectileWeaponItem.getHeldProjectile(this, supportedProjectiles);
 diff --git a/net/minecraft/world/entity/player/Player.java b/net/minecraft/world/entity/player/Player.java
-index 79f0bbfcf8ccdcbee99042d15adb5eb2338da124..03d66b77329b5da0673908ef30cc33a40c8c5ae4 100644
+index 79f0bbfcf8ccdcbee99042d15adb5eb2338da124..5d0245cb05f23d32d037daf5ea8ed333bf5ec8a5 100644
 --- a/net/minecraft/world/entity/player/Player.java
 +++ b/net/minecraft/world/entity/player/Player.java
 @@ -2119,6 +2119,12 @@ public abstract class Player extends Avatar implements ContainerUser {
@@ -54,44 +54,66 @@ index 79f0bbfcf8ccdcbee99042d15adb5eb2338da124..03d66b77329b5da0673908ef30cc33a4
          if (!(heldWeapon.getItem() instanceof ProjectileWeaponItem)) {
              return ItemStack.EMPTY;
          }
-@@ -2134,6 +2140,37 @@ public abstract class Player extends Avatar implements ContainerUser {
+@@ -2131,9 +2137,17 @@ public abstract class Player extends Avatar implements ContainerUser {
+         }
+ 
+         supportedProjectiles = ((ProjectileWeaponItem)heldWeapon.getItem()).getAllSupportedProjectiles().and(item -> this.tryReadyArrow(heldWeapon, item, anyEventCancelled)); // Paper - PlayerReadyArrowEvent
++        // Purpur start - config for turning bundles into functional quivers
++        ItemStack bundleProjectiles = getProjectileFromBundle(heldWeapon, supportedProjectiles, useBundleItemStack);
++        if (!bundleProjectiles.isEmpty()) return bundleProjectiles;
++        // Purpur end - config for turning bundles into functional quivers
  
          for (int i = 0; i < this.inventory.getContainerSize(); i++) {
              ItemStack itemStack = this.inventory.getItem(i);
 +            // Purpur start - config for turning bundles into functional quivers
-+            if ((this.level().purpurConfig.bowUseBundleAsQuiver || this.level().purpurConfig.crossbowUseBundleAsQuiver) && !this.abilities.instabuild && itemStack.getItem() instanceof net.minecraft.world.item.BundleItem) {
-+                net.minecraft.world.item.component.BundleContents bundleContents = itemStack.get(net.minecraft.core.component.DataComponents.BUNDLE_CONTENTS);
-+                if (bundleContents == null || bundleContents.isEmpty()) {
-+                    continue;
-+                }
-+
-+                Optional<ItemStack> first = bundleContents.itemCopyStream().filter(supportedProjectiles).findFirst();
-+
-+                if (first.isEmpty()) {
-+                    continue;
-+                }
-+
-+                ItemStack firstItemStack = first.get();
-+                if (useBundleItemStack) {
-+                    net.minecraft.world.item.component.BundleContents.Mutable mutable = new net.minecraft.world.item.component.BundleContents.Mutable(bundleContents);
-+                    ItemStack removedItemStack = mutable.removeOne(firstItemStack);
-+                    if (removedItemStack == null) {
-+                        continue;
-+                    }
-+
-+                    removedItemStack.shrink(1);
-+                    if (removedItemStack.getCount() != 0) {
-+                        mutable.tryInsert(removedItemStack);
-+                    }
-+                    itemStack.set(net.minecraft.core.component.DataComponents.BUNDLE_CONTENTS, mutable.toImmutable());
-+                }
-+                firstItemStack.setCount(1);
-+                return firstItemStack;
-+            }
++            bundleProjectiles = itemStack.getItem() instanceof net.minecraft.world.item.BundleItem ? getProjectileFromBundle(itemStack, supportedProjectiles, useBundleItemStack) : ItemStack.EMPTY;
++            if (!bundleProjectiles.isEmpty()) return bundleProjectiles;
 +            // Purpur end - config for turning bundles into functional quivers
              if (supportedProjectiles.test(itemStack)) {
                  return itemStack;
              }
+@@ -2143,6 +2157,41 @@ public abstract class Player extends Avatar implements ContainerUser {
+         return this.hasInfiniteMaterials() ? new ItemStack(Items.ARROW) : ItemStack.EMPTY;
+     }
+ 
++    // Purpur start - config for turning bundles into functional quivers
++    private ItemStack getProjectileFromBundle(ItemStack itemStack, Predicate<ItemStack> supportedProjectiles, boolean useBundleItemStack) {
++        if ((this.level().purpurConfig.bowUseBundleAsQuiver || this.level().purpurConfig.crossbowUseBundleAsQuiver) && !this.abilities.instabuild) {
++            net.minecraft.world.item.component.BundleContents bundleContents = itemStack.get(net.minecraft.core.component.DataComponents.BUNDLE_CONTENTS);
++            if (bundleContents == null || bundleContents.isEmpty()) {
++                return ItemStack.EMPTY;
++            }
++
++            Optional<ItemStack> first = bundleContents.itemCopyStream().filter(supportedProjectiles).findFirst();
++
++            if (first.isEmpty()) {
++                return ItemStack.EMPTY;
++            }
++
++            ItemStack firstItemStack = first.get();
++            if (useBundleItemStack) {
++                net.minecraft.world.item.component.BundleContents.Mutable mutable = new net.minecraft.world.item.component.BundleContents.Mutable(bundleContents);
++                ItemStack removedItemStack = mutable.removeOne(firstItemStack);
++                if (removedItemStack == null) {
++                    return ItemStack.EMPTY;
++                }
++
++                removedItemStack.shrink(1);
++                if (removedItemStack.getCount() != 0) {
++                    mutable.tryInsert(removedItemStack);
++                }
++                itemStack.set(net.minecraft.core.component.DataComponents.BUNDLE_CONTENTS, mutable.toImmutable());
++            }
++            firstItemStack.setCount(1);
++            return firstItemStack;
++        }
++        return ItemStack.EMPTY;
++    }
++    // Purpur end - config for turning bundles into functional quivers
++
+     @Override
+     public Vec3 getRopeHoldPosition(final float partialTickTime) {
+         double xOff = 0.22 * (this.getMainArm() == HumanoidArm.RIGHT ? -1.0 : 1.0);
 diff --git a/net/minecraft/world/item/BowItem.java b/net/minecraft/world/item/BowItem.java
 index b8ec51d5f50c15f2cd74733f762b4ddc71b573cb..cbd095207119d766b6c78e14cb4f439cd9897641 100644
 --- a/net/minecraft/world/item/BowItem.java

--- a/purpur-server/minecraft-patches/features/0022-config-for-turning-bundles-into-functional-quivers.patch
+++ b/purpur-server/minecraft-patches/features/0022-config-for-turning-bundles-into-functional-quivers.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] config for turning bundles into functional quivers
 
 
 diff --git a/net/minecraft/world/entity/LivingEntity.java b/net/minecraft/world/entity/LivingEntity.java
-index 769acea46e91e07b711fbc6a92cfcad0564f5463..b5f407d0834de3c31e1beaebaf25e5826cac4add 100644
+index 769acea46e91e07b711fbc6a92cfcad0564f5463..a99df447496225971a6be65a464e01f4f1cc6058 100644
 --- a/net/minecraft/world/entity/LivingEntity.java
 +++ b/net/minecraft/world/entity/LivingEntity.java
 @@ -4824,6 +4824,11 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
@@ -13,15 +13,15 @@ index 769acea46e91e07b711fbc6a92cfcad0564f5463..b5f407d0834de3c31e1beaebaf25e582
  
      public ItemStack getProjectile(final ItemStack heldWeapon) {
 +        // Purpur start - config for turning bundles into functional quivers
-+        return getProjectile(heldWeapon, false);
++        return getProjectile(heldWeapon, false, false);
 +    }
-+    public ItemStack getProjectile(ItemStack heldWeapon, boolean useBundleItemStack) {
++    public ItemStack getProjectile(ItemStack heldWeapon, boolean useBundleComponentStack, boolean useBundleItemStack) {
 +        // Purpur end - config for turning bundles into functional quivers
          return ItemStack.EMPTY;
      }
  
 diff --git a/net/minecraft/world/entity/monster/Monster.java b/net/minecraft/world/entity/monster/Monster.java
-index 81f1d4faebc38aa07a2c76c2c163584c8e5b624c..9bc487ebec9660682592ec99cda190d065ea5afc 100644
+index 81f1d4faebc38aa07a2c76c2c163584c8e5b624c..675b48168fd8c8ee06b67774440ff58d1c6b1b34 100644
 --- a/net/minecraft/world/entity/monster/Monster.java
 +++ b/net/minecraft/world/entity/monster/Monster.java
 @@ -154,6 +154,12 @@ public abstract class Monster extends PathfinderMob implements Enemy {
@@ -29,16 +29,16 @@ index 81f1d4faebc38aa07a2c76c2c163584c8e5b624c..9bc487ebec9660682592ec99cda190d0
      @Override
      public ItemStack getProjectile(final ItemStack heldWeapon) {
 +        // Purpur start - config for turning bundles into functional quivers
-+        return getProjectile(heldWeapon, false);
++        return getProjectile(heldWeapon, false, false);
 +    }
 +    @Override
-+    public ItemStack getProjectile(ItemStack heldWeapon, boolean useBundleItemStack) {
++    public ItemStack getProjectile(ItemStack heldWeapon, boolean useBundleComponentStack, boolean useBundleItemStack) {
 +        // Purpur end - config for turning bundles into functional quivers
          if (heldWeapon.getItem() instanceof ProjectileWeaponItem) {
              Predicate<ItemStack> supportedProjectiles = ((ProjectileWeaponItem)heldWeapon.getItem()).getSupportedHeldProjectiles();
              ItemStack heldProjectile = ProjectileWeaponItem.getHeldProjectile(this, supportedProjectiles);
 diff --git a/net/minecraft/world/entity/player/Player.java b/net/minecraft/world/entity/player/Player.java
-index 79f0bbfcf8ccdcbee99042d15adb5eb2338da124..5d0245cb05f23d32d037daf5ea8ed333bf5ec8a5 100644
+index 79f0bbfcf8ccdcbee99042d15adb5eb2338da124..0aec5c4b9c965a6f195aea4580c37c47123b0a50 100644
 --- a/net/minecraft/world/entity/player/Player.java
 +++ b/net/minecraft/world/entity/player/Player.java
 @@ -2119,6 +2119,12 @@ public abstract class Player extends Avatar implements ContainerUser {
@@ -46,39 +46,44 @@ index 79f0bbfcf8ccdcbee99042d15adb5eb2338da124..5d0245cb05f23d32d037daf5ea8ed333
      @Override
      public ItemStack getProjectile(final ItemStack heldWeapon) {
 +        // Purpur start - config for turning bundles into functional quivers
-+        return getProjectile(heldWeapon, false);
++        return getProjectile(heldWeapon, false, false);
 +    }
 +    @Override
-+    public ItemStack getProjectile(ItemStack heldWeapon, boolean useBundleItemStack) {
++    public ItemStack getProjectile(ItemStack heldWeapon, boolean useBundleComponentStack, boolean useBundleItemStack) {
 +        // Purpur end - config for turning bundles into functional quivers
          if (!(heldWeapon.getItem() instanceof ProjectileWeaponItem)) {
              return ItemStack.EMPTY;
          }
-@@ -2131,9 +2137,17 @@ public abstract class Player extends Avatar implements ContainerUser {
+@@ -2131,9 +2137,22 @@ public abstract class Player extends Avatar implements ContainerUser {
          }
  
          supportedProjectiles = ((ProjectileWeaponItem)heldWeapon.getItem()).getAllSupportedProjectiles().and(item -> this.tryReadyArrow(heldWeapon, item, anyEventCancelled)); // Paper - PlayerReadyArrowEvent
 +        // Purpur start - config for turning bundles into functional quivers
-+        ItemStack bundleProjectiles = getProjectileFromBundle(heldWeapon, supportedProjectiles, useBundleItemStack);
-+        if (!bundleProjectiles.isEmpty()) return bundleProjectiles;
++        ItemStack bundleProjectiles;
++        if (useBundleComponentStack) {
++            bundleProjectiles = getProjectileFromBundle(heldWeapon, supportedProjectiles);
++            if (!bundleProjectiles.isEmpty()) return bundleProjectiles;
++        }
 +        // Purpur end - config for turning bundles into functional quivers
  
          for (int i = 0; i < this.inventory.getContainerSize(); i++) {
              ItemStack itemStack = this.inventory.getItem(i);
 +            // Purpur start - config for turning bundles into functional quivers
-+            bundleProjectiles = itemStack.getItem() instanceof net.minecraft.world.item.BundleItem ? getProjectileFromBundle(itemStack, supportedProjectiles, useBundleItemStack) : ItemStack.EMPTY;
-+            if (!bundleProjectiles.isEmpty()) return bundleProjectiles;
++            if (useBundleItemStack) {
++                bundleProjectiles = itemStack.getItem() instanceof net.minecraft.world.item.BundleItem ? getProjectileFromBundle(itemStack, supportedProjectiles) : ItemStack.EMPTY;
++                if (!bundleProjectiles.isEmpty()) return bundleProjectiles;
++            }
 +            // Purpur end - config for turning bundles into functional quivers
              if (supportedProjectiles.test(itemStack)) {
                  return itemStack;
              }
-@@ -2143,6 +2157,41 @@ public abstract class Player extends Avatar implements ContainerUser {
+@@ -2143,6 +2162,39 @@ public abstract class Player extends Avatar implements ContainerUser {
          return this.hasInfiniteMaterials() ? new ItemStack(Items.ARROW) : ItemStack.EMPTY;
      }
  
 +    // Purpur start - config for turning bundles into functional quivers
-+    private ItemStack getProjectileFromBundle(ItemStack itemStack, Predicate<ItemStack> supportedProjectiles, boolean useBundleItemStack) {
-+        if ((this.level().purpurConfig.bowUseBundleAsQuiver || this.level().purpurConfig.crossbowUseBundleAsQuiver) && !this.abilities.instabuild) {
++    private ItemStack getProjectileFromBundle(ItemStack itemStack, Predicate<ItemStack> supportedProjectiles) {
++        if (!this.abilities.instabuild) {
 +            net.minecraft.world.item.component.BundleContents bundleContents = itemStack.get(net.minecraft.core.component.DataComponents.BUNDLE_CONTENTS);
 +            if (bundleContents == null || bundleContents.isEmpty()) {
 +                return ItemStack.EMPTY;
@@ -91,19 +96,17 @@ index 79f0bbfcf8ccdcbee99042d15adb5eb2338da124..5d0245cb05f23d32d037daf5ea8ed333
 +            }
 +
 +            ItemStack firstItemStack = first.get();
-+            if (useBundleItemStack) {
-+                net.minecraft.world.item.component.BundleContents.Mutable mutable = new net.minecraft.world.item.component.BundleContents.Mutable(bundleContents);
-+                ItemStack removedItemStack = mutable.removeOne(firstItemStack);
-+                if (removedItemStack == null) {
-+                    return ItemStack.EMPTY;
-+                }
-+
-+                removedItemStack.shrink(1);
-+                if (removedItemStack.getCount() != 0) {
-+                    mutable.tryInsert(removedItemStack);
-+                }
-+                itemStack.set(net.minecraft.core.component.DataComponents.BUNDLE_CONTENTS, mutable.toImmutable());
++            net.minecraft.world.item.component.BundleContents.Mutable mutable = new net.minecraft.world.item.component.BundleContents.Mutable(bundleContents);
++            ItemStack removedItemStack = mutable.removeOne(firstItemStack);
++            if (removedItemStack == null) {
++                return ItemStack.EMPTY;
 +            }
++
++            removedItemStack.shrink(1);
++            if (removedItemStack.getCount() != 0) {
++                mutable.tryInsert(removedItemStack);
++            }
++            itemStack.set(net.minecraft.core.component.DataComponents.BUNDLE_CONTENTS, mutable.toImmutable());
 +            firstItemStack.setCount(1);
 +            return firstItemStack;
 +        }
@@ -115,7 +118,7 @@ index 79f0bbfcf8ccdcbee99042d15adb5eb2338da124..5d0245cb05f23d32d037daf5ea8ed333
      public Vec3 getRopeHoldPosition(final float partialTickTime) {
          double xOff = 0.22 * (this.getMainArm() == HumanoidArm.RIGHT ? -1.0 : 1.0);
 diff --git a/net/minecraft/world/item/BowItem.java b/net/minecraft/world/item/BowItem.java
-index b8ec51d5f50c15f2cd74733f762b4ddc71b573cb..cbd095207119d766b6c78e14cb4f439cd9897641 100644
+index b8ec51d5f50c15f2cd74733f762b4ddc71b573cb..6df2b4e93d274ff2f06d18e22d1e02a5bcb62778 100644
 --- a/net/minecraft/world/item/BowItem.java
 +++ b/net/minecraft/world/item/BowItem.java
 @@ -25,7 +25,7 @@ public class BowItem extends ProjectileWeaponItem {
@@ -123,12 +126,12 @@ index b8ec51d5f50c15f2cd74733f762b4ddc71b573cb..cbd095207119d766b6c78e14cb4f439c
      public boolean releaseUsing(final ItemStack itemStack, final Level level, final LivingEntity entity, final int remainingTime) {
          if (entity instanceof Player player) {
 -            ItemStack projectile = player.getProjectile(itemStack);
-+            ItemStack projectile = player.getProjectile(itemStack, true); // Purpur - config for turning bundles into functional quivers
++            ItemStack projectile = player.getProjectile(itemStack, level.purpurConfig.bowUseBundleComponentAsQuiver, level.purpurConfig.bowUseBundleItemAsQuiver); // Purpur - config for turning bundles into functional quivers
              //  Purpur start - Infinity bow settings
              if (level.purpurConfig.infinityWorksWithoutArrows && projectile.isEmpty() && net.minecraft.world.item.enchantment.EnchantmentHelper.getItemEnchantmentLevel(net.minecraft.world.item.enchantment.Enchantments.INFINITY, itemStack) > 0) {
                  projectile = new ItemStack(Items.ARROW);
 diff --git a/net/minecraft/world/item/BundleItem.java b/net/minecraft/world/item/BundleItem.java
-index f64ecce370edc04c363db8bce7eda473e2764d27..636a4ed60c62e2f0b5cb4e11b5e21f7c574fdbc2 100644
+index f64ecce370edc04c363db8bce7eda473e2764d27..0094d21429195811e8ae98e3d4e41f31c9316fd3 100644
 --- a/net/minecraft/world/item/BundleItem.java
 +++ b/net/minecraft/world/item/BundleItem.java
 @@ -143,7 +143,7 @@ public class BundleItem extends Item {
@@ -136,12 +139,12 @@ index f64ecce370edc04c363db8bce7eda473e2764d27..636a4ed60c62e2f0b5cb4e11b5e21f7c
  
      private void dropContent(final Level level, final Player player, final ItemStack itemStack) {
 -        if (this.dropContent(itemStack, player)) {
-+        if (!(level.purpurConfig.bowUseBundleAsQuiver || level.purpurConfig.bowUseBundleAsQuiver) && this.dropContent(itemStack, player)) { // Purpur - config for turning bundles into functional quivers
++        if (!(level.purpurConfig.bowUseBundleItemAsQuiver || level.purpurConfig.crossbowUseBundleItemAsQuiver) && this.dropContent(itemStack, player)) { // Purpur - config for turning bundles into functional quivers
              playDropContentsSound(level, player);
              player.awardStat(Stats.ITEM_USED.get(this));
          }
 diff --git a/net/minecraft/world/item/CrossbowItem.java b/net/minecraft/world/item/CrossbowItem.java
-index d54f67ac95b1f93ea6d3db10160c68def11acc4e..e5ffc59aeabeb864910eef188c9ec6e139810331 100644
+index d54f67ac95b1f93ea6d3db10160c68def11acc4e..1a376ce0a946cb27bb801da2e1c10be430fd2f75 100644
 --- a/net/minecraft/world/item/CrossbowItem.java
 +++ b/net/minecraft/world/item/CrossbowItem.java
 @@ -68,7 +68,7 @@ public class CrossbowItem extends ProjectileWeaponItem {
@@ -158,7 +161,7 @@ index d54f67ac95b1f93ea6d3db10160c68def11acc4e..e5ffc59aeabeb864910eef188c9ec6e1
  
      private static boolean tryLoadProjectiles(final LivingEntity shooter, final ItemStack heldItem, final boolean consume) {
 -        List<ItemStack> drawn = draw(heldItem, shooter.getProjectile(heldItem), shooter, consume);
-+        List<ItemStack> drawn = draw(heldItem, shooter.getProjectile(heldItem, true), shooter, consume); // Purpur - config for turning bundles into functional quivers
++        List<ItemStack> drawn = draw(heldItem, shooter.getProjectile(heldItem, shooter.level().purpurConfig.crossbowUseBundleComponentAsQuiver, shooter.level().purpurConfig.crossbowUseBundleItemAsQuiver), shooter, consume); // Purpur - config for turning bundles into functional quivers
          // Paper end - Add EntityLoadCrossbowEvent
          if (!drawn.isEmpty()) {
              heldItem.set(DataComponents.CHARGED_PROJECTILES, ChargedProjectiles.ofNonEmpty(drawn));

--- a/purpur-server/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
+++ b/purpur-server/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
@@ -303,8 +303,10 @@ public class PurpurWorldConfig {
     public boolean snowballExtinguishesFire = false;
     public boolean snowballExtinguishesCandles = false;
     public boolean snowballExtinguishesCampfires = false;
-    public boolean bowUseBundleAsQuiver = false;
-    public boolean crossbowUseBundleAsQuiver = false;
+    public boolean bowUseBundleItemAsQuiver = false;
+    public boolean bowUseBundleComponentAsQuiver = false;
+    public boolean crossbowUseBundleItemAsQuiver = false;
+    public boolean crossbowUseBundleComponentAsQuiver = false;
     private void itemSettings() {
         itemImmuneToCactus.clear();
         getList("gameplay-mechanics.item.immune.cactus", new ArrayList<>()).forEach(key -> {
@@ -357,8 +359,10 @@ public class PurpurWorldConfig {
         snowballExtinguishesFire = getBoolean("gameplay-mechanics.item.snowball.extinguish.fire", snowballExtinguishesFire);
         snowballExtinguishesCandles = getBoolean("gameplay-mechanics.item.snowball.extinguish.candles", snowballExtinguishesCandles);
         snowballExtinguishesCampfires = getBoolean("gameplay-mechanics.item.snowball.extinguish.campfires", snowballExtinguishesCampfires);
-        bowUseBundleAsQuiver = getBoolean("gameplay-mechanics.item.bow.use-bundle-as-quiver", bowUseBundleAsQuiver);
-        crossbowUseBundleAsQuiver = getBoolean("gameplay-mechanics.item.crossbow.use-bundle-as-quiver", crossbowUseBundleAsQuiver);
+        bowUseBundleItemAsQuiver = getBoolean("gameplay-mechanics.item.bow.use-bundle-as-quiver.item", bowUseBundleItemAsQuiver);
+        bowUseBundleComponentAsQuiver = getBoolean("gameplay-mechanics.item.bow.use-bundle-as-quiver.component", bowUseBundleComponentAsQuiver);
+        crossbowUseBundleItemAsQuiver = getBoolean("gameplay-mechanics.item.crossbow.use-bundle-as-quiver.item", crossbowUseBundleItemAsQuiver);
+        crossbowUseBundleComponentAsQuiver = getBoolean("gameplay-mechanics.item.crossbow.use-bundle-as-quiver.component", crossbowUseBundleComponentAsQuiver);
     }
 
     public double minecartMaxSpeed = 0.4D;


### PR DESCRIPTION
This is made by:
- Moving the code into its own reusable method
- Check if the held weapon (bow or crossbow) contains bundle contents components, and use the arrows from that
- If that component doesn't exist or doesn't have arrows, use the same logic by checking the inventory (as the patch already does)

(Suggestion by YouHaveTrouble)