### PR TITLE
Add region packet broadcaster

### DIFF
--- a/purpur-server/src/main/java/org/purpurmc/purpur/controller/LookControllerWASD.java
+++ b/purpur-server/src/main/java/org/purpurmc/purpur/controller/LookControllerWASD.java
@@ -2,11 +2,11 @@ package org.purpurmc.purpur.controller;
 
 
 import net.minecraft.network.protocol.game.ClientboundMoveEntityPacket;
-import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.Mth;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.ai.control.LookControl;
 import net.minecraft.world.entity.player.Player;
+import org.purpurmc.purpur.network.RegionPacketBroadcaster;
 
 public class LookControllerWASD extends LookControl {
     protected final Mob entity;
@@ -50,7 +50,7 @@ public class LookControllerWASD extends LookControl {
             (byte) Mth.floor(entity.getXRot() * 256.0F / 360.0F),
             entity.onGround
         );
-        ((ServerLevel) entity.level()).getChunkSource().sendToTrackingPlayers(entity, entityPacket);
+        RegionPacketBroadcaster.instance().broadcastPacket(entity, entityPacket);
     }
 
     public void setOffsets(float yaw, float pitch) {

--- a/purpur-server/src/main/java/org/purpurmc/purpur/network/PacketBroadcastContext.java
+++ b/purpur-server/src/main/java/org/purpurmc/purpur/network/PacketBroadcastContext.java
@@ -1,0 +1,36 @@
+package org.purpurmc.purpur.network;
+
+import java.util.Objects;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.world.entity.Entity;
+
+public final class PacketBroadcastContext {
+    private final Entity entity;
+    private Packet<?> packet;
+    private boolean cancelled;
+
+    public PacketBroadcastContext(final Entity entity, final Packet<?> packet) {
+        this.entity = Objects.requireNonNull(entity, "entity");
+        this.packet = Objects.requireNonNull(packet, "packet");
+    }
+
+    public Entity entity() {
+        return this.entity;
+    }
+
+    public Packet<?> packet() {
+        return this.packet;
+    }
+
+    public void packet(final Packet<?> packet) {
+        this.packet = Objects.requireNonNull(packet, "packet");
+    }
+
+    public boolean cancelled() {
+        return this.cancelled;
+    }
+
+    public void cancel() {
+        this.cancelled = true;
+    }
+}

--- a/purpur-server/src/main/java/org/purpurmc/purpur/network/RegionPacketBroadcaster.java
+++ b/purpur-server/src/main/java/org/purpurmc/purpur/network/RegionPacketBroadcaster.java
@@ -1,6 +1,5 @@
 package org.purpurmc.purpur.network;
 
-import io.papermc.paper.threadedregions.scheduler.RegionScheduler;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -8,17 +7,16 @@ import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientGamePacketListener;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Entity;
-import org.bukkit.Location;
-import org.bukkit.plugin.Plugin;
 
 public final class RegionPacketBroadcaster {
-    private final Plugin plugin;
-    private final RegionScheduler regionScheduler;
+    private static final RegionPacketBroadcaster INSTANCE = new RegionPacketBroadcaster();
     private final AtomicReference<Consumer<PacketBroadcastContext>> lookControllerInterceptor = new AtomicReference<>();
 
-    public RegionPacketBroadcaster(final Plugin plugin, final RegionScheduler regionScheduler) {
-        this.plugin = Objects.requireNonNull(plugin, "plugin");
-        this.regionScheduler = Objects.requireNonNull(regionScheduler, "regionScheduler");
+    private RegionPacketBroadcaster() {
+    }
+
+    public static RegionPacketBroadcaster instance() {
+        return INSTANCE;
     }
 
     public void setLookControllerInterceptor(final Consumer<PacketBroadcastContext> interceptor) {
@@ -36,8 +34,7 @@ public final class RegionPacketBroadcaster {
             return;
         }
 
-        final Location location = entity.getBukkitEntity().getLocation();
-        this.regionScheduler.execute(this.plugin, location, () -> this.broadcastInRegion(entity, packet));
+        entity.getBukkitEntity().taskScheduler.scheduleOrExecute(scheduledEntity -> this.broadcastInRegion(scheduledEntity, packet));
     }
 
     private void broadcastInRegion(final Entity entity, final Packet<?> packet) {

--- a/purpur-server/src/main/java/org/purpurmc/purpur/network/RegionPacketBroadcaster.java
+++ b/purpur-server/src/main/java/org/purpurmc/purpur/network/RegionPacketBroadcaster.java
@@ -1,0 +1,62 @@
+package org.purpurmc.purpur.network;
+
+import io.papermc.paper.threadedregions.scheduler.RegionScheduler;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.game.ClientGamePacketListener;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.Entity;
+import org.bukkit.Location;
+import org.bukkit.plugin.Plugin;
+
+public final class RegionPacketBroadcaster {
+    private final Plugin plugin;
+    private final RegionScheduler regionScheduler;
+    private final AtomicReference<Consumer<PacketBroadcastContext>> lookControllerInterceptor = new AtomicReference<>();
+
+    public RegionPacketBroadcaster(final Plugin plugin, final RegionScheduler regionScheduler) {
+        this.plugin = Objects.requireNonNull(plugin, "plugin");
+        this.regionScheduler = Objects.requireNonNull(regionScheduler, "regionScheduler");
+    }
+
+    public void setLookControllerInterceptor(final Consumer<PacketBroadcastContext> interceptor) {
+        this.lookControllerInterceptor.set(interceptor);
+    }
+
+    public void clearLookControllerInterceptor() {
+        this.lookControllerInterceptor.set(null);
+    }
+
+    public void broadcastPacket(final Entity entity, final Packet<?> packet) {
+        Objects.requireNonNull(entity, "entity");
+        Objects.requireNonNull(packet, "packet");
+        if (entity.isRemoved()) {
+            return;
+        }
+
+        final Location location = entity.getBukkitEntity().getLocation();
+        this.regionScheduler.execute(this.plugin, location, () -> this.broadcastInRegion(entity, packet));
+    }
+
+    private void broadcastInRegion(final Entity entity, final Packet<?> packet) {
+        if (entity.isRemoved() || !(entity.level() instanceof ServerLevel level)) {
+            return;
+        }
+
+        final PacketBroadcastContext context = new PacketBroadcastContext(entity, packet);
+        final Consumer<PacketBroadcastContext> interceptor = this.lookControllerInterceptor.get();
+        if (interceptor != null) {
+            interceptor.accept(context);
+        }
+        if (!context.cancelled()) {
+            this.sendToTrackingPlayers(level, entity, context.packet());
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void sendToTrackingPlayers(final ServerLevel level, final Entity entity, final Packet<?> packet) {
+        level.getChunkSource().sendToTrackingPlayers(entity, (Packet<? super ClientGamePacketListener>) packet);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `RegionPacketBroadcaster` for scheduling entity tracker packet broadcasts through Folia's `RegionScheduler`.
- Add `PacketBroadcastContext` to allow packet replacement or cancellation.
- Add a thread-safe look-controller packet interception hook.

## Validation

- Ran `./gradlew applyAllPatches`
- Ran `./gradlew :purpur-server:compileJava`