### PR TITLE
Add leaves instant decay option

### DIFF
--- a/purpur-server/minecraft-patches/sources/net/minecraft/world/level/block/LeavesBlock.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/world/level/block/LeavesBlock.java.patch
@@ -1,0 +1,10 @@
+--- a/net/minecraft/world/level/block/LeavesBlock.java
++++ b/net/minecraft/world/level/block/LeavesBlock.java
+@@ -86,6 +_,7 @@
+     @Override
+     protected void tick(final BlockState state, final ServerLevel level, final BlockPos pos, final RandomSource random) {
+         level.setBlock(pos, updateDistance(state, level, pos), Block.UPDATE_ALL);
++        if (level.purpurConfig.leavesInstantDecay) this.randomTick(state, level, pos, random); // Purpur - Instant leaves decay
+     }
+ 
+     @Override

--- a/purpur-server/minecraft-patches/sources/net/minecraft/world/level/block/LeavesBlock.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/world/level/block/LeavesBlock.java.patch
@@ -1,10 +1,23 @@
 --- a/net/minecraft/world/level/block/LeavesBlock.java
 +++ b/net/minecraft/world/level/block/LeavesBlock.java
+@@ -65,6 +_,12 @@
+ 
+     @Override
+     protected void randomTick(final BlockState state, final ServerLevel level, final BlockPos pos, final RandomSource random) {
++        // Purpur start - Instant leaves decay
++        if (!level.purpurConfig.leavesInstantDecay) checkDecay(state, level, pos, random);
++    }
++
++    protected void checkDecay(final BlockState state, final ServerLevel level, final BlockPos pos, final RandomSource random) {
++        // Purpur end - Instant leaves decay
+         if (this.decaying(state)) {
+             // CraftBukkit start
+             org.bukkit.event.block.LeavesDecayEvent event = new org.bukkit.event.block.LeavesDecayEvent(org.bukkit.craftbukkit.block.CraftBlock.at(level, pos));
 @@ -86,6 +_,7 @@
      @Override
      protected void tick(final BlockState state, final ServerLevel level, final BlockPos pos, final RandomSource random) {
          level.setBlock(pos, updateDistance(state, level, pos), Block.UPDATE_ALL);
-+        if (level.purpurConfig.leavesInstantDecay) this.randomTick(state, level, pos, random); // Purpur - Instant leaves decay
++        if (level.purpurConfig.leavesInstantDecay) checkDecay(state, level, pos, random); // Purpur - Instant leaves decay
      }
  
      @Override

--- a/purpur-server/minecraft-patches/sources/net/minecraft/world/level/block/LeavesBlock.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/world/level/block/LeavesBlock.java.patch
@@ -8,7 +8,7 @@
 +        if (!level.purpurConfig.leavesInstantDecay) checkDecay(state, level, pos, random);
 +    }
 +
-+    protected void checkDecay(final BlockState state, final ServerLevel level, final BlockPos pos, final RandomSource random) {
++    private void checkDecay(final BlockState state, final ServerLevel level, final BlockPos pos, final RandomSource random) {
 +        // Purpur end - Instant leaves decay
          if (this.decaying(state)) {
              // CraftBukkit start

--- a/purpur-server/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
+++ b/purpur-server/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
@@ -3899,4 +3899,9 @@ public class PurpurWorldConfig {
         shearsCanDefuseTntChance = (float) getDouble("gameplay-mechanics.item.shears.defuse-tnt-chance", 0.00D);
         shearsCanDefuseTnt = shearsCanDefuseTntChance > 0.00F;
     }
+
+    public boolean leavesInstantDecay = false;
+    private void leavesSettings() {
+        leavesInstantDecay = getBoolean("blocks.leaves.instant-decay", leavesInstantDecay);
+    }
 }


### PR DESCRIPTION
Add a new option to instant decay the leaves after breaking a tree.

Note that even if `randomTick()` gets called every tick in `tick()` , it doesn't have any performance issues even if it runs on ALL leaves, since for leaves not decaying, it's just a boolean check and return.

I tested this and I didn't see any issues. This would be a nice addition since doing it with a plugin requires a bit more logic and might not be as intended.

How this works:
https://discord.com/channels/685683385313919172/720374890472931328/1525151676447723523

Update: thanks to Billy's suggestion, we made a new method instead of randomTick, so depending on the config, only one of them will fire (either decay on randomTick, or decay on tick if config is enabled)