### PR TITLE
Fix configured lightning-spawned horse being discarded

### DIFF
--- a/purpur-server/minecraft-patches/sources/net/minecraft/server/level/ServerLevel.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/server/level/ServerLevel.java.patch
@@ -49,13 +49,17 @@
 +                        if (skeletonHorse != null) ((SkeletonHorse) skeletonHorse).setTrap(true);
 +                    }
 +                    // Purpur end - Special mobs naturally spawn
-                     SkeletonHorse horse = EntityTypes.SKELETON_HORSE.create(this, EntitySpawnReason.EVENT);
-                     if (horse != null) {
+-                    SkeletonHorse horse = EntityTypes.SKELETON_HORSE.create(this, EntitySpawnReason.EVENT);
+-                    if (horse != null) {
 -                        horse.setTrap(true);
-+                        //horse.setTrap(true); // Purpur - Special mobs naturally spawn - moved up
-                         horse.setAge(0);
-                         horse.setPos(pos.getX(), pos.getY(), pos.getZ());
-                         this.addFreshEntity(horse, org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason.LIGHTNING); // CraftBukkit
+-                        horse.setAge(0);
+-                        horse.setPos(pos.getX(), pos.getY(), pos.getZ());
+-                        this.addFreshEntity(horse, org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason.LIGHTNING); // CraftBukkit
++                    if (skeletonHorse != null) {
++                        //skeletonHorse.setTrap(true); // Purpur - Special mobs naturally spawn - moved up
++                        skeletonHorse.setAge(0);
++                        skeletonHorse.setPos(pos.getX(), pos.getY(), pos.getZ());
++                        this.addFreshEntity(skeletonHorse, org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason.LIGHTNING); // CraftBukkit
 @@ -1088,9 +_,35 @@
                  if (state.is(Blocks.SNOW)) {
                      int currentLayers = state.getValue(SnowLayerBlock.LAYERS);


### PR DESCRIPTION
### Fixes #1804 

## Description

During natural lightning spawning, Purpur configured a skeleton or zombie horse instance, but then created and added a second unconfigured skeleton horse to the world. This discarded the trap state and could leave an untamed, non-trap skeleton horse with a `LIGHTNING` spawn reason.

This change reuses the configured horse instance when setting its age and position and adding it to the world. This also restores the mobs.zombie_horse.spawn-chance behavior, because the selected zombie horse is now added to the world instead of being discarded.

## Testing

- Applied all Minecraft patches successfully.
- Ran a clean full build with `gradlew build --rerun-tasks`.
- Reproduced the issue using natural thunder.
- Verified that the spawned skeleton horse has `SkeletonTrap: 1b`.
- Verified that approaching the horse triggers the skeleton trap normally.