### PR TITLE
Fix one punch man not killing some mobs

### DIFF
--- a/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
@@ -97,7 +97,7 @@
 +
 +                if (attackDamage.doubleValue() == 0.0D) {
 +                    // One punch!
-+                    damage = this.getHealth();
++                    damage = Float.MAX_VALUE;
 +                }
 +            }
 +        }


### PR DESCRIPTION
It looks like there are checks after for the absorption, armor, resistance etc... that decreases the damage amount, so using `getHealth()` won't kill the mobs with those modifiers (wither, zombie etc...)

The best fix it to set the damage to the max value possible `Float.MAX_VALUE. This is more appropriate and also safe since we have a check after the damage:
```java
if (Float.isNaN(damage) || Float.isInfinite(damage)) {
    damage = Float.MAX_VALUE;
}
```

Fixes #1811 