### PR TITLE
Add option to include Illusioners in raids.

### DIFF
--- a/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/raid/Raid.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/raid/Raid.java.patch
@@ -4,25 +4,30 @@
      private Raid.RaidStatus status;
      private int celebrationTicks;
      private Optional<BlockPos> waveSpawnPos = Optional.empty();
-+    public boolean includeIllusioners;
++    public boolean includeIllusioners; // Purpur - workaround variable
  
      public Raid(final BlockPos center, final Difficulty difficulty) {
          this.active = true;
-@@ -550,8 +_,12 @@
+@@ -550,8 +_,14 @@
          this.totalHealth = 0.0F;
          DifficultyInstance difficulty = level.getCurrentDifficultyAt(pos);
          boolean isBonusGroup = this.shouldSpawnBonusGroup();
-+        includeIllusioners = level.purpurConfig.illusionerSpawnInRaids;
++        includeIllusioners = level.purpurConfig.illusionerSpawnInRaids; // Purpur - update the variable to match the setting
  
          for (Raid.RaiderType raiderType : Raid.RaiderType.VALUES) {
++            // Purpur start - exclude Illusioners if the feature is disabled
 +            if (raiderType == Raid.RaiderType.ILLUSIONER && !this.includeIllusioners) {
 +                continue;
 +            }
++            // Purpur end
              int numSpawns = this.getDefaultNumSpawns(raiderType, groupNumber, isBonusGroup)
                  + this.getPotentialBonusSpawns(raiderType, this.random, groupNumber, difficulty, isBonusGroup);
              int ravagersSpawned = 0;
-@@ -575,7 +_,13 @@
+@@ -573,9 +_,17 @@
+                     Raider ridingRaider = null;
+                     if (groupNumber == this.getNumGroups(Difficulty.NORMAL)) {
                          ridingRaider = EntityTypes.PILLAGER.create(level, EntitySpawnReason.EVENT);
++                        // Purpur start - use the setting to determine if Ravagers with Illusioners should spawn
                      } else if (groupNumber >= this.getNumGroups(Difficulty.HARD)) {
                          if (ravagersSpawned == 0) {
 -                            ridingRaider = EntityTypes.EVOKER.create(level, EntitySpawnReason.EVENT);
@@ -33,6 +38,7 @@
 +                            } else {
 +                                ridingRaider = EntityTypes.EVOKER.create(level, EntitySpawnReason.EVENT);
 +                            }
++                            // Purpur end
                          } else {
                              ridingRaider = EntityTypes.VINDICATOR.create(level, EntitySpawnReason.EVENT);
                          }
@@ -40,7 +46,7 @@
          int bonusSpawns;
          switch (type) {
              case VINDICATOR:
-+            case ILLUSIONER:
++            case ILLUSIONER: // Purpur - add case for Illusioners
              case PILLAGER:
                  if (isEasy) {
                      bonusSpawns = random.nextInt(2);
@@ -48,7 +54,7 @@
          VINDICATOR(EntityTypes.VINDICATOR, new int[]{0, 0, 2, 0, 1, 4, 2, 5}),
          EVOKER(EntityTypes.EVOKER, new int[]{0, 0, 0, 0, 0, 1, 1, 2}),
          PILLAGER(EntityTypes.PILLAGER, new int[]{0, 4, 3, 3, 4, 4, 4, 2}),
-+        ILLUSIONER(EntityTypes.ILLUSIONER, new int[]{0, 0, 1, 0, 1, 1, 0, 1}),
++        ILLUSIONER(EntityTypes.ILLUSIONER, new int[]{0, 0, 1, 0, 1, 1, 0, 1}), // Purpur - add Illusioners to RaiderType
          WITCH(EntityTypes.WITCH, new int[]{0, 0, 0, 0, 3, 0, 0, 1}),
          RAVAGER(EntityTypes.RAVAGER, new int[]{0, 0, 0, 1, 0, 1, 0, 2});
  

--- a/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/raid/Raid.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/raid/Raid.java.patch
@@ -1,0 +1,54 @@
+--- a/net/minecraft/world/entity/raid/Raid.java
++++ b/net/minecraft/world/entity/raid/Raid.java
+@@ -132,6 +_,7 @@
+     private Raid.RaidStatus status;
+     private int celebrationTicks;
+     private Optional<BlockPos> waveSpawnPos = Optional.empty();
++    public boolean includeIllusioners;
+ 
+     public Raid(final BlockPos center, final Difficulty difficulty) {
+         this.active = true;
+@@ -550,8 +_,12 @@
+         this.totalHealth = 0.0F;
+         DifficultyInstance difficulty = level.getCurrentDifficultyAt(pos);
+         boolean isBonusGroup = this.shouldSpawnBonusGroup();
++        includeIllusioners = level.purpurConfig.illusionerSpawnInRaids;
+ 
+         for (Raid.RaiderType raiderType : Raid.RaiderType.VALUES) {
++            if (raiderType == Raid.RaiderType.ILLUSIONER && !this.includeIllusioners) {
++                continue;
++            }
+             int numSpawns = this.getDefaultNumSpawns(raiderType, groupNumber, isBonusGroup)
+                 + this.getPotentialBonusSpawns(raiderType, this.random, groupNumber, difficulty, isBonusGroup);
+             int ravagersSpawned = 0;
+@@ -575,7 +_,13 @@
+                         ridingRaider = EntityTypes.PILLAGER.create(level, EntitySpawnReason.EVENT);
+                     } else if (groupNumber >= this.getNumGroups(Difficulty.HARD)) {
+                         if (ravagersSpawned == 0) {
+-                            ridingRaider = EntityTypes.EVOKER.create(level, EntitySpawnReason.EVENT);
++                            if (level.purpurConfig.illusionerSpawnInRaids) {
++                                ridingRaider = random.nextBoolean()
++                                    ? EntityTypes.EVOKER.create(level, EntitySpawnReason.EVENT)
++                                    : EntityTypes.ILLUSIONER.create(level, EntitySpawnReason.EVENT);
++                            } else {
++                                ridingRaider = EntityTypes.EVOKER.create(level, EntitySpawnReason.EVENT);
++                            }
+                         } else {
+                             ridingRaider = EntityTypes.VINDICATOR.create(level, EntitySpawnReason.EVENT);
+                         }
+@@ -782,6 +_,7 @@
+         int bonusSpawns;
+         switch (type) {
+             case VINDICATOR:
++            case ILLUSIONER:
+             case PILLAGER:
+                 if (isEasy) {
+                     bonusSpawns = random.nextInt(2);
+@@ -867,6 +_,7 @@
+         VINDICATOR(EntityTypes.VINDICATOR, new int[]{0, 0, 2, 0, 1, 4, 2, 5}),
+         EVOKER(EntityTypes.EVOKER, new int[]{0, 0, 0, 0, 0, 1, 1, 2}),
+         PILLAGER(EntityTypes.PILLAGER, new int[]{0, 4, 3, 3, 4, 4, 4, 2}),
++        ILLUSIONER(EntityTypes.ILLUSIONER, new int[]{0, 0, 1, 0, 1, 1, 0, 1}),
+         WITCH(EntityTypes.WITCH, new int[]{0, 0, 0, 0, 3, 0, 0, 1}),
+         RAVAGER(EntityTypes.RAVAGER, new int[]{0, 0, 0, 1, 0, 1, 0, 2});
+ 

--- a/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/raid/Raid.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/raid/Raid.java.patch
@@ -1,29 +1,19 @@
 --- a/net/minecraft/world/entity/raid/Raid.java
 +++ b/net/minecraft/world/entity/raid/Raid.java
-@@ -552,6 +_,9 @@
+@@ -552,6 +_,7 @@
          boolean isBonusGroup = this.shouldSpawnBonusGroup();
  
          for (Raid.RaiderType raiderType : Raid.RaiderType.VALUES) {
-+            // Purpur start - exclude Illusioners if the feature is disabled
-+            if (raiderType == Raid.RaiderType.ILLUSIONER && !level.purpurConfig.illusionerSpawnInRaids) { continue; }
-+            // Purpur end
++            if (raiderType == Raid.RaiderType.ILLUSIONER && !level.purpurConfig.illusionerSpawnInRaids) { continue; } // Purpur - Ability for Illusioners to spawn during raids
              int numSpawns = this.getDefaultNumSpawns(raiderType, groupNumber, isBonusGroup)
                  + this.getPotentialBonusSpawns(raiderType, this.random, groupNumber, difficulty, isBonusGroup);
              int ravagersSpawned = 0;
-@@ -570,12 +_,15 @@
- 
-                 this.joinRaid(level, groupNumber, raider, pos, false);
-                 if (raiderType.entityType == EntityTypes.RAVAGER) {
-+
-                     Raider ridingRaider = null;
-                     if (groupNumber == this.getNumGroups(Difficulty.NORMAL)) {
+@@ -575,7 +_,7 @@
                          ridingRaider = EntityTypes.PILLAGER.create(level, EntitySpawnReason.EVENT);
-+                        // Purpur start - use the setting to determine if Ravagers with Illusioners should spawn
                      } else if (groupNumber >= this.getNumGroups(Difficulty.HARD)) {
                          if (ravagersSpawned == 0) {
 -                            ridingRaider = EntityTypes.EVOKER.create(level, EntitySpawnReason.EVENT);
-+                            ridingRaider = (level.purpurConfig.illusionerSpawnInRaids && random.nextBoolean() ? EntityTypes.ILLUSIONER : EntityTypes.EVOKER).create(level, EntitySpawnReason.EVENT); // Purpur
-+                            // Purpur end
++                            ridingRaider = (level.purpurConfig.illusionerSpawnInRaids && random.nextBoolean() ? EntityTypes.ILLUSIONER : EntityTypes.EVOKER).create(level, EntitySpawnReason.EVENT); // Purpur - Ability for Illusioners to spawn during raids
                          } else {
                              ridingRaider = EntityTypes.VINDICATOR.create(level, EntitySpawnReason.EVENT);
                          }
@@ -39,7 +29,7 @@
          VINDICATOR(EntityTypes.VINDICATOR, new int[]{0, 0, 2, 0, 1, 4, 2, 5}),
          EVOKER(EntityTypes.EVOKER, new int[]{0, 0, 0, 0, 0, 1, 1, 2}),
          PILLAGER(EntityTypes.PILLAGER, new int[]{0, 4, 3, 3, 4, 4, 4, 2}),
-+        ILLUSIONER(EntityTypes.ILLUSIONER, new int[]{0, 0, 1, 0, 1, 1, 0, 1}), // Purpur - Add Illusioners to RaiderType
++        ILLUSIONER(EntityTypes.ILLUSIONER, new int[]{0, 0, 1, 0, 1, 1, 0, 1}), // Purpur - Ability for Illusioners to spawn during raids
          WITCH(EntityTypes.WITCH, new int[]{0, 0, 0, 0, 3, 0, 0, 1}),
          RAVAGER(EntityTypes.RAVAGER, new int[]{0, 0, 0, 1, 0, 1, 0, 2});
  

--- a/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/raid/Raid.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/raid/Raid.java.patch
@@ -1,22 +1,11 @@
 --- a/net/minecraft/world/entity/raid/Raid.java
 +++ b/net/minecraft/world/entity/raid/Raid.java
-@@ -132,6 +_,7 @@
-     private Raid.RaidStatus status;
-     private int celebrationTicks;
-     private Optional<BlockPos> waveSpawnPos = Optional.empty();
-+    public boolean includeIllusioners; // Purpur - workaround variable
- 
-     public Raid(final BlockPos center, final Difficulty difficulty) {
-         this.active = true;
-@@ -550,8 +_,14 @@
-         this.totalHealth = 0.0F;
-         DifficultyInstance difficulty = level.getCurrentDifficultyAt(pos);
+@@ -552,6 +_,11 @@
          boolean isBonusGroup = this.shouldSpawnBonusGroup();
-+        includeIllusioners = level.purpurConfig.illusionerSpawnInRaids; // Purpur - update the variable to match the setting
  
          for (Raid.RaiderType raiderType : Raid.RaiderType.VALUES) {
 +            // Purpur start - exclude Illusioners if the feature is disabled
-+            if (raiderType == Raid.RaiderType.ILLUSIONER && !this.includeIllusioners) {
++            if (raiderType == Raid.RaiderType.ILLUSIONER && !level.purpurConfig.illusionerSpawnInRaids) {
 +                continue;
 +            }
 +            // Purpur end
@@ -46,7 +35,7 @@
          int bonusSpawns;
          switch (type) {
              case VINDICATOR:
-+            case ILLUSIONER: // Purpur - add case for Illusioners
++            case ILLUSIONER: // Purpur - Ability for illusioners to spawn during raids
              case PILLAGER:
                  if (isEasy) {
                      bonusSpawns = random.nextInt(2);
@@ -54,7 +43,7 @@
          VINDICATOR(EntityTypes.VINDICATOR, new int[]{0, 0, 2, 0, 1, 4, 2, 5}),
          EVOKER(EntityTypes.EVOKER, new int[]{0, 0, 0, 0, 0, 1, 1, 2}),
          PILLAGER(EntityTypes.PILLAGER, new int[]{0, 4, 3, 3, 4, 4, 4, 2}),
-+        ILLUSIONER(EntityTypes.ILLUSIONER, new int[]{0, 0, 1, 0, 1, 1, 0, 1}), // Purpur - add Illusioners to RaiderType
++        ILLUSIONER(EntityTypes.ILLUSIONER, new int[]{0, 0, 1, 0, 1, 1, 0, 1}), // Purpur - Add Illusioners to RaiderType
          WITCH(EntityTypes.WITCH, new int[]{0, 0, 0, 0, 3, 0, 0, 1}),
          RAVAGER(EntityTypes.RAVAGER, new int[]{0, 0, 0, 1, 0, 1, 0, 2});
  

--- a/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/raid/Raid.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/raid/Raid.java.patch
@@ -1,18 +1,20 @@
 --- a/net/minecraft/world/entity/raid/Raid.java
 +++ b/net/minecraft/world/entity/raid/Raid.java
-@@ -552,6 +_,11 @@
+@@ -552,6 +_,9 @@
          boolean isBonusGroup = this.shouldSpawnBonusGroup();
  
          for (Raid.RaiderType raiderType : Raid.RaiderType.VALUES) {
 +            // Purpur start - exclude Illusioners if the feature is disabled
-+            if (raiderType == Raid.RaiderType.ILLUSIONER && !level.purpurConfig.illusionerSpawnInRaids) {
-+                continue;
-+            }
++            if (raiderType == Raid.RaiderType.ILLUSIONER && !level.purpurConfig.illusionerSpawnInRaids) { continue; }
 +            // Purpur end
              int numSpawns = this.getDefaultNumSpawns(raiderType, groupNumber, isBonusGroup)
                  + this.getPotentialBonusSpawns(raiderType, this.random, groupNumber, difficulty, isBonusGroup);
              int ravagersSpawned = 0;
-@@ -573,9 +_,17 @@
+@@ -570,12 +_,15 @@
+ 
+                 this.joinRaid(level, groupNumber, raider, pos, false);
+                 if (raiderType.entityType == EntityTypes.RAVAGER) {
++
                      Raider ridingRaider = null;
                      if (groupNumber == this.getNumGroups(Difficulty.NORMAL)) {
                          ridingRaider = EntityTypes.PILLAGER.create(level, EntitySpawnReason.EVENT);
@@ -20,13 +22,7 @@
                      } else if (groupNumber >= this.getNumGroups(Difficulty.HARD)) {
                          if (ravagersSpawned == 0) {
 -                            ridingRaider = EntityTypes.EVOKER.create(level, EntitySpawnReason.EVENT);
-+                            if (level.purpurConfig.illusionerSpawnInRaids) {
-+                                ridingRaider = random.nextBoolean()
-+                                    ? EntityTypes.EVOKER.create(level, EntitySpawnReason.EVENT)
-+                                    : EntityTypes.ILLUSIONER.create(level, EntitySpawnReason.EVENT);
-+                            } else {
-+                                ridingRaider = EntityTypes.EVOKER.create(level, EntitySpawnReason.EVENT);
-+                            }
++                            ridingRaider = (level.purpurConfig.illusionerSpawnInRaids && random.nextBoolean() ? EntityTypes.ILLUSIONER : EntityTypes.EVOKER).create(level, EntitySpawnReason.EVENT); // Purpur
 +                            // Purpur end
                          } else {
                              ridingRaider = EntityTypes.VINDICATOR.create(level, EntitySpawnReason.EVENT);
@@ -35,7 +31,7 @@
          int bonusSpawns;
          switch (type) {
              case VINDICATOR:
-+            case ILLUSIONER: // Purpur - Ability for illusioners to spawn during raids
++            case ILLUSIONER: // Purpur - Ability for Illusioners to spawn during raids
              case PILLAGER:
                  if (isEasy) {
                      bonusSpawns = random.nextInt(2);

--- a/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/raid/Raid.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/raid/Raid.java.patch
@@ -4,7 +4,7 @@
          boolean isBonusGroup = this.shouldSpawnBonusGroup();
  
          for (Raid.RaiderType raiderType : Raid.RaiderType.VALUES) {
-+            if (raiderType == Raid.RaiderType.ILLUSIONER && !level.purpurConfig.illusionerSpawnInRaids) { continue; } // Purpur - Ability for Illusioners to spawn during raids
++            if (!level.purpurConfig.illusionerSpawnInRaids && raiderType == Raid.RaiderType.ILLUSIONER) continue; // Purpur - Ability for Illusioners to spawn during raids
              int numSpawns = this.getDefaultNumSpawns(raiderType, groupNumber, isBonusGroup)
                  + this.getPotentialBonusSpawns(raiderType, this.random, groupNumber, difficulty, isBonusGroup);
              int ravagersSpawned = 0;

--- a/purpur-server/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
+++ b/purpur-server/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
@@ -2275,6 +2275,7 @@ public class PurpurWorldConfig {
     public double illusionerScale = 1.0D;
     public boolean illusionerTakeDamageFromWater = false;
     public boolean illusionerAlwaysDropExp = false;
+    public boolean illusionerSpawnInRaids = false;
     private void illusionerSettings() {
         illusionerRidable = getBoolean("mobs.illusioner.ridable", illusionerRidable);
         illusionerRidableInWater = getBoolean("mobs.illusioner.ridable-in-water", illusionerRidableInWater);
@@ -2294,6 +2295,7 @@ public class PurpurWorldConfig {
         illusionerScale = Mth.clamp(getDouble("mobs.illusioner.attributes.scale", illusionerScale), 0.0625D, 16.0D);
         illusionerTakeDamageFromWater = getBoolean("mobs.illusioner.takes-damage-from-water", illusionerTakeDamageFromWater);
         illusionerAlwaysDropExp = getBoolean("mobs.illusioner.always-drop-exp", illusionerAlwaysDropExp);
+        illusionerSpawnInRaids = getBoolean("mobs.illusioner.spawn-in-raids", illusionerSpawnInRaids);
     }
 
     public boolean ironGolemRidable = false;


### PR DESCRIPTION
I'd like to suggest adding a "spawn-in-raids" setting for Illusioners. Having these mobs as a part of raids would add a nice challenge.

By default, the feature is disabled. However, players can opt in by changing it to "true" in the "purpur.yml" file.