### PR TITLE
Add commands for managing operators

### DIFF
--- a/purpur-server/minecraft-patches/sources/net/minecraft/commands/Commands.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/commands/Commands.java.patch
@@ -14,7 +14,7 @@
              RaidCommand.register(this.dispatcher, context);
              DebugPathCommand.register(this.dispatcher);
              DebugMobSpawningCommand.register(this.dispatcher);
-@@ -300,6 +_,14 @@
+@@ -300,6 +_,17 @@
              StopCommand.register(this.dispatcher);
              TransferCommand.register(this.dispatcher);
              WhitelistCommand.register(this.dispatcher);
@@ -26,6 +26,9 @@
 +            org.purpurmc.purpur.command.CompassCommand.register(this.dispatcher); // Purpur - Add compass command
 +            org.purpurmc.purpur.command.RamBarCommand.register(this.dispatcher); // Purpur - Add rambar command
 +            org.purpurmc.purpur.command.RamCommand.register(this.dispatcher); // Purpur - Add ram command
++            org.purpurmc.purpur.command.OPInfoCommand.register(this.dispatcher); // Purpur - Add opinfo command
++            org.purpurmc.purpur.command.OPLevelCommand.register(this.dispatcher); // Purpur - Add oplevel command
++            org.purpurmc.purpur.command.BypassPlayerLimitCommand.register(this.dispatcher); // Purpur - Add bypassplayerlimit command
          }
  
          if (commandSelection.includeIntegrated) {

--- a/purpur-server/src/main/java/org/purpurmc/purpur/command/BypassPlayerLimitCommand.java
+++ b/purpur-server/src/main/java/org/purpurmc/purpur/command/BypassPlayerLimitCommand.java
@@ -1,0 +1,66 @@
+package org.purpurmc.purpur.command;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.BoolArgumentType;
+import net.minecraft.ChatFormatting;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.commands.arguments.GameProfileArgument;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.permissions.Permissions;
+import net.minecraft.server.players.NameAndId;
+import net.minecraft.server.players.ServerOpList;
+import net.minecraft.server.players.ServerOpListEntry;
+
+import java.util.Collection;
+
+public class BypassPlayerLimitCommand {
+    public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
+        dispatcher.register(Commands.literal("bypassplayerlimit")
+            .requires(listener -> listener.hasPermission(Permissions.COMMANDS_OWNER, "bukkit.command.bypassplayerlimit"))
+            .then(Commands.argument("targets", GameProfileArgument.gameProfile())
+                .then(Commands.argument("bypass", BoolArgumentType.bool())
+                    .executes(context -> execute(
+                        context.getSource(),
+                        GameProfileArgument.getGameProfiles(context, "targets"),
+                        BoolArgumentType.getBool(context, "bypass")
+                    ))
+                )
+            )
+        );
+    }
+
+    private static int execute(CommandSourceStack source, Collection<NameAndId> targets, boolean bypass) {
+        ServerOpList opList = source.getServer().getPlayerList().getOps();
+        int count = 0;
+
+        for (NameAndId nameAndId : targets) {
+            ServerOpListEntry existingEntry = opList.get(nameAndId);
+
+            if (existingEntry == null) {
+                source.sendFailure(Component.literal(nameAndId.name() + " is not an operator.").withStyle(ChatFormatting.RED));
+                continue;
+            }
+
+            ServerOpListEntry newEntry = new ServerOpListEntry(
+                nameAndId,
+                existingEntry.permissions(),
+                bypass
+            );
+
+            opList.add(newEntry);
+
+            Component message = Component.empty()
+                .append(Component.literal("Set bypass player limit privilege for ").withStyle(ChatFormatting.WHITE))
+                .append(Component.literal(nameAndId.name()).withStyle(ChatFormatting.AQUA))
+                .append(Component.literal(" to ").withStyle(ChatFormatting.WHITE))
+                .append(Component.literal(String.valueOf(bypass)).withStyle(bypass ? ChatFormatting.GREEN : ChatFormatting.RED))
+                .append(Component.literal(".").withStyle(ChatFormatting.WHITE));
+
+            source.sendSuccess(() -> message, true);
+            count++;
+        }
+
+        return count;
+    }
+}

--- a/purpur-server/src/main/java/org/purpurmc/purpur/command/OPInfoCommand.java
+++ b/purpur-server/src/main/java/org/purpurmc/purpur/command/OPInfoCommand.java
@@ -1,0 +1,85 @@
+package org.purpurmc.purpur.command;
+
+import com.mojang.brigadier.CommandDispatcher;
+import net.minecraft.ChatFormatting;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.commands.arguments.GameProfileArgument;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.permissions.PermissionLevel;
+import net.minecraft.server.permissions.Permissions;
+import net.minecraft.server.players.NameAndId;
+import net.minecraft.server.players.ServerOpList;
+import net.minecraft.server.players.ServerOpListEntry;
+
+import java.util.Collection;
+
+public class OPInfoCommand {
+    public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
+        dispatcher.register(Commands.literal("opinfo")
+            .requires(listener -> listener.hasPermission(Permissions.COMMANDS_OWNER, "bukkit.command.opinfo"))
+            .executes(context -> executeList(context.getSource()))
+            .then(Commands.argument("targets", GameProfileArgument.gameProfile())
+                .executes(context -> executePlayer(
+                    context.getSource(),
+                    GameProfileArgument.getGameProfiles(context, "targets")
+                ))
+            )
+        );
+    }
+
+    private static int executeList(CommandSourceStack source) {
+        ServerOpList opList = source.getServer().getPlayerList().getOps();
+        Collection<ServerOpListEntry> entries = opList.getEntries();
+
+        if (entries.isEmpty()) {
+            source.sendFailure(Component.literal("There are no operators on this server.").withStyle(ChatFormatting.RED));
+            return 0;
+        }
+
+        source.sendSuccess(() -> Component.literal("--- Operators ---").withStyle(ChatFormatting.BLUE), false);
+        for (ServerOpListEntry entry : entries) {
+            formatAndSendEntry(source, entry);
+        }
+
+        return entries.size();
+    }
+
+    private static int executePlayer(CommandSourceStack source, Collection<NameAndId> targets) {
+        ServerOpList opList = source.getServer().getPlayerList().getOps();
+        int count = 0;
+
+        for (NameAndId nameAndId : targets) {
+            ServerOpListEntry entry = opList.get(nameAndId);
+
+            if (entry == null) {
+                source.sendFailure(Component.literal(nameAndId.name() + " is not an operator.").withStyle(ChatFormatting.RED));
+            } else {
+                formatAndSendEntry(source, entry);
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    private static void formatAndSendEntry(CommandSourceStack source, ServerOpListEntry entry) {
+        NameAndId user = entry.getUser();
+        String name = (user != null) ? user.name() : "Unknown";
+
+        PermissionLevel level = entry.permissions().level();
+        boolean bypassesLimit = entry.getBypassesPlayerLimit();
+
+        Component info = Component.empty()
+            .append(Component.literal("- ").withStyle(ChatFormatting.GRAY))
+            .append(Component.literal(name).withStyle(ChatFormatting.AQUA))
+            .append(Component.literal(" | ").withStyle(ChatFormatting.GRAY))
+            .append(Component.literal("Level: ").withStyle(ChatFormatting.WHITE))
+            .append(Component.literal(String.valueOf(level)).withStyle(ChatFormatting.AQUA))
+            .append(Component.literal(" | ").withStyle(ChatFormatting.GRAY))
+            .append(Component.literal("Bypasses Player Limit: ").withStyle(ChatFormatting.WHITE))
+            .append(Component.literal(String.valueOf(bypassesLimit)).withStyle(bypassesLimit ? ChatFormatting.GREEN : ChatFormatting.RED));
+
+        source.sendSuccess(() -> info, false);
+    }
+}

--- a/purpur-server/src/main/java/org/purpurmc/purpur/command/OPLevelCommand.java
+++ b/purpur-server/src/main/java/org/purpurmc/purpur/command/OPLevelCommand.java
@@ -1,0 +1,76 @@
+package org.purpurmc.purpur.command;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.IntegerArgumentType;
+import net.minecraft.ChatFormatting;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.commands.arguments.GameProfileArgument;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.permissions.LevelBasedPermissionSet;
+import net.minecraft.server.permissions.PermissionLevel;
+import net.minecraft.server.permissions.Permissions;
+import net.minecraft.server.players.NameAndId;
+import net.minecraft.server.players.ServerOpList;
+import net.minecraft.server.players.ServerOpListEntry;
+
+import java.util.Collection;
+
+public class OPLevelCommand {
+    public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
+        dispatcher.register(Commands.literal("oplevel")
+            .requires(listener -> listener.hasPermission(Permissions.COMMANDS_OWNER, "bukkit.command.oplevel"))
+            .then(Commands.argument("targets", GameProfileArgument.gameProfile())
+                .then(Commands.argument("level", IntegerArgumentType.integer(0, 4))
+                    .executes(context -> execute(
+                        context.getSource(),
+                        GameProfileArgument.getGameProfiles(context, "targets"),
+                        IntegerArgumentType.getInteger(context, "level")
+                    ))
+                )
+            )
+        );
+    }
+
+    private static int execute(CommandSourceStack source, Collection<NameAndId> targets, int newLevel) {
+        MinecraftServer server = source.getServer();
+        ServerOpList opList = server.getPlayerList().getOps();
+        int count = 0;
+
+        for (NameAndId nameAndId : targets) {
+            ServerOpListEntry existingEntry = opList.get(nameAndId);
+
+            if (existingEntry == null) {
+                source.sendFailure(Component.literal(nameAndId.name() + " is not an operator.").withStyle(ChatFormatting.RED));
+                continue;
+            }
+
+            ServerOpListEntry newEntry = new ServerOpListEntry(
+                nameAndId,
+                LevelBasedPermissionSet.forLevel(PermissionLevel.byId(newLevel)),
+                existingEntry.getBypassesPlayerLimit()
+            );
+
+            opList.add(newEntry);
+
+            ServerPlayer serverPlayer = server.getPlayerList().getPlayer(nameAndId.id());
+            if (serverPlayer != null) {
+                server.getPlayerList().sendPlayerPermissionLevel(serverPlayer);
+            }
+
+            Component message = Component.empty()
+                .append(Component.literal("Set operator level for ").withStyle(ChatFormatting.WHITE))
+                .append(Component.literal(nameAndId.name()).withStyle(ChatFormatting.AQUA))
+                .append(Component.literal(" to level ").withStyle(ChatFormatting.WHITE))
+                .append(Component.literal(String.valueOf(newLevel)).withStyle(ChatFormatting.AQUA))
+                .append(Component.literal(".").withStyle(ChatFormatting.WHITE));
+
+            source.sendSuccess(() -> message, true);
+            count++;
+        }
+
+        return count;
+    }
+}


### PR DESCRIPTION
I would like to suggest implementing commands for managing operators.

Currently, there is no way to change a player's operator level without editing the "ops.json" file. Similarly, you cannot change the value of "bypassesPlayerLimit" without editing the file.

This addition would allow server owners to have more control over players they grant operator privileges to. The "/oplevel" command can be used to change the permission level, while "/bypassplayerlimit" changes the value of the "bypassesPlayerLimit" entry.

There is also an "/opinfo" command, which shows a list of operators and allows you to see information for a specific player.

Having these commands alongside a permissions plugin would allow for even better customisation of a server's permission setup. This would be especially helpful in cases where a functionality does not have a working permission node.