### PR TITLE
Add system property which overrides IS_RUNNING_IN_IDE

### DIFF
--- a/purpur-server/minecraft-patches/sources/net/minecraft/SharedConstants.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/SharedConstants.java.patch
@@ -5,7 +5,7 @@
      public static final boolean USE_DEVONLY = false;
      public static boolean CHECK_DATA_FIXER_SCHEMA = true;
 -    public static boolean IS_RUNNING_IN_IDE;
-+    public static boolean IS_RUNNING_IN_IDE = booleanProperty("purpur.isRunningInIDE");
++    public static boolean IS_RUNNING_IN_IDE = booleanProperty("purpur.isRunningInIDE"); // Purpur - add a system property which overrides IS_RUNNING_IN_IDE
      public static final int WORLD_RESOLUTION = 16;
      public static final int MAX_CHAT_LENGTH = 256;
      public static final int MAX_USER_INPUT_COMMAND_LENGTH = 32500;

--- a/purpur-server/minecraft-patches/sources/net/minecraft/SharedConstants.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/SharedConstants.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/SharedConstants.java
++++ b/net/minecraft/SharedConstants.java
+@@ -125,7 +_,7 @@
+     public static final float MAXIMUM_BLOCK_EXPLOSION_RESISTANCE = 3600000.0F;
+     public static final boolean USE_DEVONLY = false;
+     public static boolean CHECK_DATA_FIXER_SCHEMA = true;
+-    public static boolean IS_RUNNING_IN_IDE;
++    public static boolean IS_RUNNING_IN_IDE = booleanProperty("purpur.isRunningInIDE");
+     public static final int WORLD_RESOLUTION = 16;
+     public static final int MAX_CHAT_LENGTH = 256;
+     public static final int MAX_USER_INPUT_COMMAND_LENGTH = 32500;


### PR DESCRIPTION
I'd like to suggest the addition of a "purpur.isRunningInIDE" system property. This is a simple patch that has a big impact: it overrides the "IS_RUNNING_IN_IDE" flag. The "IS_RUNNING_IN_IDE" flag controls access to many functionalities that are hidden within the game's code.

If the system property is added, a mixin loader will no longer be required to override the "IS_RUNNING_IN_IDE" flag. All players will have to do is add "-Dpurpur.isRunningInIDE=true" to their startup script, and the job is done.