### PR TITLE
Default burp delay option to 0 instead of 10 (vanilla behavior)

### DIFF
--- a/purpur-server/minecraft-patches/sources/net/minecraft/world/food/FoodProperties.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/world/food/FoodProperties.java.patch
@@ -1,17 +1,15 @@
 --- a/net/minecraft/world/food/FoodProperties.java
 +++ b/net/minecraft/world/food/FoodProperties.java
-@@ -42,9 +_,11 @@
+@@ -42,6 +_,12 @@
          level.playSound(null, user.getX(), user.getY(), user.getZ(), consumable.sound().value(), SoundSource.NEUTRAL, 1.0F, random.triangle(1.0F, 0.4F));
          if (user instanceof Player player) {
              player.getFoodData().eat(this, stack, (net.minecraft.server.level.ServerPlayer) player); // CraftBukkit
--            level.playSound(
--                null, player.getX(), player.getY(), player.getZ(), SoundEvents.PLAYER_BURP, SoundSource.PLAYERS, 0.5F, Mth.randomBetween(random, 0.9F, 1.0F)
--            );
 +            // Purpur start - Burp delay - moved to Player#tick()
-+            //level.playSound(
-+            //    null, player.getX(), player.getY(), player.getZ(), SoundEvents.PLAYER_BURP, SoundSource.PLAYERS, 0.5F, Mth.randomBetween(random, 0.9F, 1.0F)
-+            //);
++            if (player.level().purpurConfig.playerBurpDelay > 0) {
++                player.burpDelay = player.level().purpurConfig.playerBurpDelay;
++                return;
++            }
 +            // Purpur end - Burp delay - moved to Player#tick()
-         }
-     }
- 
+             level.playSound(
+                 null, player.getX(), player.getY(), player.getZ(), SoundEvents.PLAYER_BURP, SoundSource.PLAYERS, 0.5F, Mth.randomBetween(random, 0.9F, 1.0F)
+             );

--- a/purpur-server/minecraft-patches/sources/net/minecraft/world/food/FoodProperties.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/world/food/FoodProperties.java.patch
@@ -1,14 +1,10 @@
 --- a/net/minecraft/world/food/FoodProperties.java
 +++ b/net/minecraft/world/food/FoodProperties.java
-@@ -42,6 +_,11 @@
+@@ -42,6 +_,7 @@
          level.playSound(null, user.getX(), user.getY(), user.getZ(), consumable.sound().value(), SoundSource.NEUTRAL, 1.0F, random.triangle(1.0F, 0.4F));
          if (user instanceof Player player) {
              player.getFoodData().eat(this, stack, (net.minecraft.server.level.ServerPlayer) player); // CraftBukkit
-+            // Purpur start - Burp delay - moved to Player#tick()
-+            if (player.level().purpurConfig.playerBurpDelay > 0) {
-+                return;
-+            }
-+            // Purpur end - Burp delay - moved to Player#tick()
++            if (player.level().purpurConfig.playerBurpDelay > 0) return; // Purpur - Burp delay - moved to Player#tick()
              level.playSound(
                  null, player.getX(), player.getY(), player.getZ(), SoundEvents.PLAYER_BURP, SoundSource.PLAYERS, 0.5F, Mth.randomBetween(random, 0.9F, 1.0F)
              );

--- a/purpur-server/minecraft-patches/sources/net/minecraft/world/food/FoodProperties.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/world/food/FoodProperties.java.patch
@@ -1,12 +1,11 @@
 --- a/net/minecraft/world/food/FoodProperties.java
 +++ b/net/minecraft/world/food/FoodProperties.java
-@@ -42,6 +_,12 @@
+@@ -42,6 +_,11 @@
          level.playSound(null, user.getX(), user.getY(), user.getZ(), consumable.sound().value(), SoundSource.NEUTRAL, 1.0F, random.triangle(1.0F, 0.4F));
          if (user instanceof Player player) {
              player.getFoodData().eat(this, stack, (net.minecraft.server.level.ServerPlayer) player); // CraftBukkit
 +            // Purpur start - Burp delay - moved to Player#tick()
 +            if (player.level().purpurConfig.playerBurpDelay > 0) {
-+                player.burpDelay = player.level().purpurConfig.playerBurpDelay;
 +                return;
 +            }
 +            // Purpur end - Burp delay - moved to Player#tick()

--- a/purpur-server/src/main/java/org/purpurmc/purpur/PurpurConfig.java
+++ b/purpur-server/src/main/java/org/purpurmc/purpur/PurpurConfig.java
@@ -74,8 +74,8 @@ public class PurpurConfig {
         commands = new HashMap<>();
         commands.put("purpur", new PurpurCommand("purpur"));
 
-        version = getInt("config-version", 48);
-        set("config-version", 48);
+        version = getInt("config-version", 49);
+        set("config-version", 49);
 
         readConfig(PurpurConfig.class, null);
 

--- a/purpur-server/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
+++ b/purpur-server/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
@@ -499,6 +499,10 @@ public class PurpurWorldConfig {
             set("gameplay-mechanics.player.idle-timeout.mods-target", null);
             set("gameplay-mechanics.player.idle-timeout.mobs-target", oldVal);
         }
+        if (PurpurConfig.version < 49) {
+            int oldVal = getInt("gameplay-mechanics.player.burp-delay", playerBurpDelay);
+            if (oldVal == 10) set("gameplay-mechanics.player.burp-delay", 0);
+        }
         idleTimeoutKick = System.getenv("PURPUR_FORCE_IDLE_KICK") == null ? getBoolean("gameplay-mechanics.player.idle-timeout.kick-if-idle", idleTimeoutKick) : Boolean.parseBoolean(System.getenv("PURPUR_FORCE_IDLE_KICK"));
         idleTimeoutTickNearbyEntities = getBoolean("gameplay-mechanics.player.idle-timeout.tick-nearby-entities", idleTimeoutTickNearbyEntities);
         idleTimeoutCountAsSleeping = getBoolean("gameplay-mechanics.player.idle-timeout.count-as-sleeping", idleTimeoutCountAsSleeping);

--- a/purpur-server/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
+++ b/purpur-server/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
@@ -486,7 +486,7 @@ public class PurpurWorldConfig {
     public boolean playerSleepNearMonsters = false;
     public boolean playersSkipNight = true;
     public double playerCriticalDamageMultiplier = 1.5D;
-    public int playerBurpDelay = 10;
+    public int playerBurpDelay = 0;
     public boolean playerBurpWhenFull = false;
     public boolean playerRidableInWater = false;
     public boolean playerRemoveBindingWithWeakness = false;


### PR DESCRIPTION
Vanilla behavior of playing the burp sound immediately after finishing eating (i.e. `burp-delay: 0`) was previously impossible; this PR restores the logic to play the vanilla burp sound if burp delay is <= 0. Also sets the `burp-delay` to `0` by default as per vanilla behavior.

Awaiting feedback of which method is desirable (early return vs. if/else).

Partially addresses #1826 (`burp-delay: 0` case)

Set as draft until I finish testing.