### PR TITLE
[ci skip] Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Use the command `./gradlew build` to build the API and server. Compiled JARs
 will be placed under `purpur-api/build/libs` and `purpur-server/build/libs`.
 **These JARs are not used to start a server.**
 
-To compile a server-ready purpurclip jar, run `./gradlew createMojmapBundlerJar`.
+To compile a server-ready purpurclip jar, run `./gradlew createPaperclipJar`.
 To install the `purpur-api` and `purpur` dependencies to your local Maven repo, run `./gradlew publishToMavenLocal`. The compiled purpurclip jar will be in `purpur-server/build/libs`.
 
 Special Thanks To:


### PR DESCRIPTION
All I know is `createMojmapBundlerJar` doesn't exist anymore and this appears to be the renamed task.