### PR TITLE
Change the default permissions for "/plugins" and "/version".

### DIFF
--- a/purpur-api/paper-patches/files/src/main/java/org/bukkit/util/permissions/CommandPermissions.java.patch
+++ b/purpur-api/paper-patches/files/src/main/java/org/bukkit/util/permissions/CommandPermissions.java.patch
@@ -5,10 +5,10 @@
  
          DefaultPermissions.registerPermission(PREFIX + "help", "Allows the user to view the vanilla help menu", PermissionDefault.TRUE, commands);
 -        DefaultPermissions.registerPermission(PREFIX + "plugins", "Allows the user to view the list of plugins running on this server", PermissionDefault.TRUE, commands);
-+        DefaultPermissions.registerPermission(PREFIX + "plugins", "Allows the user to view the list of plugins running on this server", PermissionDefault.OP, commands);
++        DefaultPermissions.registerPermission(PREFIX + "plugins", "Allows the user to view the list of plugins running on this server", PermissionDefault.OP, commands); // Purpur - Require operator privileges to see installed plugins
          DefaultPermissions.registerPermission(PREFIX + "reload", "Allows the user to reload the server settings", PermissionDefault.OP, commands);
 -        DefaultPermissions.registerPermission(PREFIX + "version", "Allows the user to view the version of the server", PermissionDefault.TRUE, commands);
-+        DefaultPermissions.registerPermission(PREFIX + "version", "Allows the user to view the version of the server", PermissionDefault.OP, commands);
++        DefaultPermissions.registerPermission(PREFIX + "version", "Allows the user to view the version of the server", PermissionDefault.OP, commands); // Purpur - Require operator privileges to see server version
 +        DefaultPermissions.registerPermission(PREFIX + "purpur", "Allows the user to use the purpur command", PermissionDefault.OP, commands); // Purpur - Default permissions
  
          commands.recalculatePermissibles();

--- a/purpur-api/paper-patches/files/src/main/java/org/bukkit/util/permissions/CommandPermissions.java.patch
+++ b/purpur-api/paper-patches/files/src/main/java/org/bukkit/util/permissions/CommandPermissions.java.patch
@@ -1,9 +1,14 @@
 --- a/src/main/java/org/bukkit/util/permissions/CommandPermissions.java
 +++ b/src/main/java/org/bukkit/util/permissions/CommandPermissions.java
-@@ -18,6 +_,7 @@
-         DefaultPermissions.registerPermission(PREFIX + "plugins", "Allows the user to view the list of plugins running on this server", PermissionDefault.TRUE, commands);
+@@ -15,9 +_,10 @@
+         Permission commands = DefaultPermissions.registerPermission(ROOT, "Gives the user the ability to use all CraftBukkit commands", parent);
+ 
+         DefaultPermissions.registerPermission(PREFIX + "help", "Allows the user to view the vanilla help menu", PermissionDefault.TRUE, commands);
+-        DefaultPermissions.registerPermission(PREFIX + "plugins", "Allows the user to view the list of plugins running on this server", PermissionDefault.TRUE, commands);
++        DefaultPermissions.registerPermission(PREFIX + "plugins", "Allows the user to view the list of plugins running on this server", PermissionDefault.OP, commands);
          DefaultPermissions.registerPermission(PREFIX + "reload", "Allows the user to reload the server settings", PermissionDefault.OP, commands);
-         DefaultPermissions.registerPermission(PREFIX + "version", "Allows the user to view the version of the server", PermissionDefault.TRUE, commands);
+-        DefaultPermissions.registerPermission(PREFIX + "version", "Allows the user to view the version of the server", PermissionDefault.TRUE, commands);
++        DefaultPermissions.registerPermission(PREFIX + "version", "Allows the user to view the version of the server", PermissionDefault.OP, commands);
 +        DefaultPermissions.registerPermission(PREFIX + "purpur", "Allows the user to use the purpur command", PermissionDefault.OP, commands); // Purpur - Default permissions
  
          commands.recalculatePermissibles();


### PR DESCRIPTION
I would like to suggest changing the default value of the permission nodes for some of the built-in commands.

At present, all players can execute "/plugins". Regular players do not need access to the list of plugins a server has installed. It is better to let the server owner decide if someone should be able to see what plugins they have installed instead of granting access to it by default.

Regular players do not need access to "/version" either. It would be better to restrict this command to operators as well, just like with the "/purpur version" command.